### PR TITLE
ENH: Make kafka bootstrap servers configurable

### DIFF
--- a/slam/kafka_reader.py
+++ b/slam/kafka_reader.py
@@ -2,7 +2,7 @@ import json
 from kafka import KafkaConsumer
 from kafka.consumer.fetcher import ConsumerRecord
 from qtpy.QtCore import QObject, Signal
-from typing import Callable
+from typing import Callable, List
 
 
 class KafkaReader(QObject):
@@ -13,17 +13,19 @@ class KafkaReader(QObject):
     ----------
     topic_name : str
         The name of the topic to subscribe to. Will also subscribe to the command topic as well
+    bootstrap_servers : List[str]
+        A list containing one or more urls for kafka bootstrap servers
     new_message_slot : Callable
         The slot function that each message will end up at
     """
 
     new_message_signal = Signal(ConsumerRecord)  # Emitted for every new message received
 
-    def __init__(self, topic_name: str, new_message_slot: Callable):
+    def __init__(self, topic_name: str, bootstrap_servers: List[str], new_message_slot: Callable):
         self.topic_name = topic_name
         self.main_consumer = KafkaConsumer(topic_name,
                                            f'{topic_name}Command',
-                                           bootstrap_servers=['localhost:9092'],
+                                           bootstrap_servers=bootstrap_servers,
                                            auto_offset_reset='earliest',
                                            enable_auto_commit=False,
                                            key_deserializer=lambda x: x.decode('utf-8'),

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -6,7 +6,7 @@ from kafka import KafkaProducer
 from pydm.widgets import PyDMArchiverTimePlot
 from qtpy.QtCore import QThread, Signal, Slot
 from qtpy.QtWidgets import QAction, QApplication, QMainWindow, QTabWidget
-from typing import Optional
+from typing import List, Optional
 from .alarm_item import AlarmSeverity
 from .alarm_table_view import AlarmTableViewWidget
 from .alarm_tree_view import AlarmTreeViewWidget
@@ -25,14 +25,16 @@ class AlarmHandlerMainWindow(QMainWindow):
 
     topic : str
         The kafka topic to listen to
+    bootstrap_servers : List[str]
+        A list containing one or more urls for kafka bootstrap servers
     """
 
     alarm_update_signal = Signal(str, str, AlarmSeverity, str, datetime, str, AlarmSeverity, str)
 
-    def __init__(self, topic: str):
+    def __init__(self, topic: str, bootstrap_servers: List[str]):
         super().__init__()
 
-        self.kafka_producer = KafkaProducer(bootstrap_servers=['localhost:9092'],
+        self.kafka_producer = KafkaProducer(bootstrap_servers=bootstrap_servers,
                                             value_serializer=lambda x: json.dumps(x).encode('utf-8'),
                                             key_serializer=lambda x: x.encode('utf-8'))
         self.topic = topic

--- a/slam/tests/test_main_window.py
+++ b/slam/tests/test_main_window.py
@@ -13,7 +13,7 @@ def main_window(monkeypatch, mock_kafka_producer):
     monkeypatch.setattr(KafkaReader, 'moveToThread', lambda *args: None)
     monkeypatch.setattr(QThread, 'start', lambda *args: None)
 
-    main_window = AlarmHandlerMainWindow('TEST_TOPIC')
+    main_window = AlarmHandlerMainWindow('TEST_TOPIC', ['localhost:9092'])
     return main_window
 
 

--- a/slam_launcher/main.py
+++ b/slam_launcher/main.py
@@ -9,14 +9,19 @@ from slam import AlarmHandlerMainWindow
 def main():
     parser = argparse.ArgumentParser(description="SLAC Alarm Manager")
     parser.add_argument('--topic', help='Kafka alarm topic to listen to')
+    parser.add_argument('--bootstrap-servers',
+                        default='localhost:9092',
+                        help='Comma separated list of urls for one or more kafka boostrap servers')
     parser.add_argument('--log', default='warning', help='Logging level. debug, info, warning, error, critical')
 
     app_args = parser.parse_args()
 
     logging.basicConfig(level=app_args.log.upper())
 
+    kafka_boostrap_servers = app_args.bootstrap_servers.split(',')
+
     app = QApplication([])
-    main_window = AlarmHandlerMainWindow(app_args.topic)
+    main_window = AlarmHandlerMainWindow(app_args.topic, kafka_boostrap_servers)
     main_window.resize(1035, 600)
     main_window.setWindowTitle('SLAC Alarm Manager')
     main_window.show()


### PR DESCRIPTION
Adds an extra argument when starting up the application to point to the location of the bootstrap server(s) for kafka.