### PR TITLE
ENH: Add a PyDM data plugin for receiving alarm data from NALMS

### DIFF
--- a/pydm_alarm_plugin/README.md
+++ b/pydm_alarm_plugin/README.md
@@ -1,6 +1,6 @@
 # AlarmPlugin
 
-The `AlarmPlugin` class is a `PyDMPlugin` with support for reading alarm information from a kafka cluster. 
+The `AlarmPlugin` class is a `PyDMPlugin` with support for reading alarm information from the NALMS kafka cluster.
 It uses an entry point in order to be discoverable by `PyDM` such that installing this package into an environment which 
 contains `PyDM` will allow it to be used. See here for more information: https://slaclab.github.io/pydm/data_plugins/external_plugins.html
 
@@ -9,6 +9,6 @@ set to the kafka topic to consume messages from. And `PYDM_KAFKA_BOOTSTRAP_SERVE
 connecting to the kafka cluster. If either of these is not set, the connection to the cluster will not be made and
 no messages will be read.
 
-To use this plugin with PyDM displays, the new protocol `alarm://` has been created. Any widget which specifies a 
-channel starting with `alarm://` will be routed to the `AlarmPlugin`, and any updates to the alarm severity of the
+To use this plugin with PyDM displays, the new protocol `nalms://` has been created. Any widget which specifies a
+channel starting with `nalms://` will be routed to the `AlarmPlugin`, and any updates to the alarm severity of the
 channel being monitored will be sent back to the widget.

--- a/pydm_alarm_plugin/README.md
+++ b/pydm_alarm_plugin/README.md
@@ -1,0 +1,14 @@
+# AlarmPlugin
+
+The `AlarmPlugin` class is a `PyDMPlugin` with support for reading alarm information from a kafka cluster. 
+It uses an entry point in order to be discoverable by `PyDM` such that installing this package into an environment which 
+contains `PyDM` will allow it to be used. See here for more information: https://slaclab.github.io/pydm/data_plugins/external_plugins.html
+
+In order to connect to kafka correctly, two environment variable must be specified. `PYDM_KAFKA_ALARM_TOPIC` must be
+set to the kafka topic to consume messages from. And `PYDM_KAFKA_BOOTSTRAP_SERVERS` must be set to the correct url for
+connecting to the kafka cluster. If either of these is not set, the connection to the cluster will not be made and
+no messages will be read.
+
+To use this plugin with PyDM displays, the new protocol `alarm://` has been created. Any widget which specifies a 
+channel starting with `alarm://` will be routed to the `AlarmPlugin`, and any updates to the alarm severity of the
+channel being monitored will be sent back to the widget.

--- a/pydm_alarm_plugin/alarm_plugin.py
+++ b/pydm_alarm_plugin/alarm_plugin.py
@@ -1,0 +1,113 @@
+import logging
+import os
+from kafka.consumer.fetcher import ConsumerRecord
+from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
+from pydm.utilities import remove_protocol
+from pydm.widgets.base import PyDMWidget
+from pydm.widgets.channel import PyDMChannel
+from qtpy.QtCore import QObject, QThread
+from slam.alarm_item import AlarmSeverity
+from slam.kafka_reader import KafkaReader
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+kafka_logger = logging.getLogger('kafka')
+kafka_logger.setLevel('WARNING')  # Anything less results in too much noise
+
+
+class Connection(PyDMConnection):
+    """
+    A PyDMConnection for sending alarm severity signals to all listeners which have been registered with it.
+    """
+    def __init__(self, channel: PyDMChannel, address: str, protocol: Optional[str] = None,
+                 parent: Optional[QObject] = None):
+        super().__init__(channel, address, protocol, parent)
+        self.add_listener(channel)
+
+    def send_alarm_data(self, severity: AlarmSeverity):
+        """
+        Sends the updated alarm severity to all listeners of this connection.
+
+        Parameters
+        ----------
+        severity : AlarmSeverity
+            The updated severity which will be emitted as the new_severity_signal
+        """
+        if severity is AlarmSeverity.OK:
+            self.new_severity_signal.emit(PyDMWidget.ALARM_NONE)
+        elif severity is AlarmSeverity.MINOR:
+            self.new_severity_signal.emit(PyDMWidget.ALARM_MINOR)
+        elif severity is AlarmSeverity.MAJOR:
+            self.new_severity_signal.emit(PyDMWidget.ALARM_MAJOR)
+        elif severity is AlarmSeverity.INVALID:
+            self.new_severity_signal.emit(PyDMWidget.ALARM_INVALID)
+        elif severity is AlarmSeverity.UNDEFINED:
+            self.new_severity_signal.emit(PyDMWidget.ALARM_DISCONNECTED)
+
+
+class AlarmPlugin(PyDMPlugin):
+    """
+    Manages the data flow between the kafka queue for alarm data and the PyDM display widgets. Currently this is
+    read-only as no write actions can be taken from PyDM widgets for now.
+    """
+    protocol = "alarm"
+    connection_class = Connection
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        kafka_topic = os.getenv('PYDM_KAFKA_ALARM_TOPIC')
+        kafka_bootstrap_servers = os.getenv('PYDM_KAFKA_BOOTSTRAP_SERVERS')
+        if not kafka_topic:
+            logger.debug('Could not initialize alarm data plugin, topic must be specified in the '
+                         'PYDM_KAFKA_ALARM_TOPIC environment variable')
+            return
+        if not kafka_bootstrap_servers:
+            logger.debug('Could not initialize alarm data plugin, kafka bootstrap server location must be '
+                         'specified in the PYDM_KAFKA_BOOTSTRAP_SERVERS environment variable')
+            return
+
+        self.alarm_severities = dict()  # Mapping from alarm name to current alarm severity
+        self.kafka_reader = KafkaReader(kafka_topic, kafka_bootstrap_servers.split(','), self.process_message)
+        self.kafka_topic = kafka_topic
+        self.processing_thread = QThread()
+        self.kafka_reader.moveToThread(self.processing_thread)
+        self.processing_thread.started.connect(self.kafka_reader.run)
+        self.processing_thread.start()
+
+    def add_connection(self, channel: PyDMChannel):
+        """
+        Add the input channel to the set of channels this data plugin is connected with. Will send the current
+        alarm value to the channel upon connecting, and continue to send alarm updates to the channel for as long
+        as it remains connected.
+
+        Parameters
+        ----------
+        channel : PyDMChannel
+            The channel to establish a connection with
+        """
+        super(AlarmPlugin, self).add_connection(channel)
+        alarm_name = remove_protocol(channel.address)
+        if alarm_name in self.alarm_severities:
+            self.connections[alarm_name].send_alarm_data(self.alarm_severities[alarm_name])
+
+    def process_message(self, message: ConsumerRecord):
+        """
+        Process a message received from kafka and send the alarm severity to any channels listening for updates to the
+        key of the message received.
+
+        Parameters
+        ----------
+        message : ConsumerRecord
+            A message received from the kafka queue indicating a new message for the topic we are listening to
+        """
+        if message.key.startswith('state') and message.value is not None and 'severity' in message.value:
+            # Start from [6:] to skip over the "state:" part of the key.
+            # An example key could look something like: state:/top-level-system/sub-system/sub-component/PV:NAME
+            alarm_path = message.key[6:]
+            alarm_name = alarm_path.split('/')[-1]
+            if alarm_name != self.kafka_topic:
+                current_severity = AlarmSeverity(message.value['severity'])
+                self.alarm_severities[alarm_name] = current_severity
+                if alarm_name in self.connections:
+                    self.connections[alarm_name].send_alarm_data(current_severity)

--- a/pydm_alarm_plugin/alarm_plugin.py
+++ b/pydm_alarm_plugin/alarm_plugin.py
@@ -51,7 +51,7 @@ class AlarmPlugin(PyDMPlugin):
     Manages the data flow between the kafka queue for alarm data and the PyDM display widgets. Currently this is
     read-only as no write actions can be taken from PyDM widgets for now.
     """
-    protocol = "alarm"
+    protocol = "nalms"
     connection_class = Connection
 
     def __init__(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,11 @@ setup(
     name='slac-alarm-manager',
     version='0.1.0',
     description='Python interface for managing alarms',
-    url='https://github.com/jbellister-slac/slam',
-    packages=['slam', 'slam_launcher'],
-    install_requires=['kafka-python', 'qtpy'],
-    entry_points={'console_scripts': ['slam=slam_launcher.main:main']},
+    url='https://github.com/slaclab/slac-alarm-manager',
+    packages=['slam', 'slam_launcher', 'pydm_alarm_plugin'],
+    install_requires=['kafka-python', 'pydm', 'qtpy'],
+    entry_points={
+        'console_scripts': ['slam=slam_launcher.main:main'],
+        'pydm.data_plugin': ['pydm_alarm_plugin=pydm_alarm_plugin.alarm_plugin:AlarmPlugin']
+    },
 )

--- a/slam/tests/test_alarm_plugin.py
+++ b/slam/tests/test_alarm_plugin.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest import mock
+from pydm import PyDMChannel
+from pydm.widgets.base import PyDMWidget
+
+from pydm_alarm_plugin.alarm_plugin import AlarmPlugin, Connection
+
+
+@mock.patch('kafka.consumer.fetcher.ConsumerRecord', autospec=True)
+@pytest.mark.parametrize('severity_from_kafka, signal_to_send', [
+    ('OK', PyDMWidget.ALARM_NONE),
+    ('MINOR', PyDMWidget.ALARM_MINOR),
+    ('MAJOR', PyDMWidget.ALARM_MAJOR),
+    ('INVALID', PyDMWidget.ALARM_INVALID),
+    ('UNDEFINED', PyDMWidget.ALARM_DISCONNECTED)
+])
+def test_process_message(mock_record, severity_from_kafka, signal_to_send):
+    """
+    The alarm data plugin maintains a list of connections for receiving updates to alarm severities. This tests
+    that when a new message from kafka arrives that a connection is listening for, the plugin will notify
+    that connection to emit the correct signal.
+
+    Parameters
+    ----------
+    mock_record : ConsumerRecord
+        A mock up of a message that will be received by the kafka consumer
+    severity_from_kafka : str
+        The new alarm severity received from kafka
+    signal_to_send : int
+        The severity value that PyDM is expecting to receive
+    """
+
+    # Setup the alarm plugin and an associated connection
+    alarm_plugin = AlarmPlugin()
+    alarm_plugin.kafka_topic = 'test_topic'
+    alarm_plugin.alarm_severities = {}
+    alarm_channel = PyDMChannel()
+    alarm_connection = Connection(alarm_channel, 'pva://TEST:ADDRESS')
+
+    # Setup a way for verifying the signals emitted
+    received_values = []
+
+    def receive_signal(value_received: object):
+        """ A simple slot for receiving all our test signals and storing the values to ensure they are as expected """
+        received_values.append(value_received)
+    alarm_connection.new_severity_signal.connect(receive_signal)
+
+    # Create the mock record to receive from kafka
+    mock_record.key = 'state:/top_level_summary/component_summary/motors'
+    mock_record.value = {'message': 'state_alarm', 'severity': severity_from_kafka}
+
+    # At first no signals should be sent because no connections have been established with the plugin
+    alarm_plugin.process_message(mock_record)
+    assert len(received_values) == 0
+
+    # Now add a connection, and verify the signal is emitted as expected
+    alarm_plugin.connections['motors'] = alarm_connection
+    alarm_plugin.process_message(mock_record)
+    assert len(received_values) == 1
+    assert received_values[0] == signal_to_send


### PR DESCRIPTION
Hi all,

I wanted to draw some attention to this part of the alarm work I've been doing since it would affect PyDM if installed alongside it.

### Motivation and Context

We are in the process of rolling out the new alarm system (NALMS) (https://slaclab.github.io/nalms/) which is based heavily on the phoebus alarm server. Phoebus sends out alarm updates using a kafka cluster, allowing clients to read/write to kafka instead of EPICS directly.

When building a screen like lclshome, the current way to get top level alarm summaries for the buttons is to create an alarm IOC, which is an IOC that has alarm summary PVs which are set to the highest severity of the PVs which make up each summary PV. See the second heading here: https://www.slac.stanford.edu/grp/lcls/controls/sysGroup/LCLS%20Alarms.htm

In a brand new installation of NALMS where no existing alarm IOCs are present, such as we are doing with PCDS, it makes less sense to create that kind of alarm IOC alongside it since it would be duplicating the work and maintenance of building up summaries that the phoebus side already does for us.

### How it works

This plugin leverages the work Ken did to add entrypoint support for PyDM data plugins. When this package is installed alongside PyDM, the plugin can be discovered and initialized. Similar to the archiver plugin, proper initialization will require the definition of the two environment variables mentioned in the readme. If the alarm protocol is not needed, leaving these variables unset will ensure no connection to kafka is attempted.

Widgets can then specify channels that are alarm summaries, even if there is no IOC backing them since it will be reading updates from kafka. For example, from this configuration: https://github.com/pcdshub/pcds-nalms/blob/master/XML/KFE/GMDXGMD.xml

`alarm://GMD high voltage` results in a widget with an alarm summary of all the PVs underlying `GMD high voltage`. `alarm://GMD` would also be valid, resulting in summary of each summary component under `GMD`

### Screenshot

![alarm_summary](https://user-images.githubusercontent.com/89539359/185676791-0a6f5529-a12b-4234-9069-34a8c85ebad2.gif)

### Functionality still to be added

If this approach looks good, I will still need to allow multiple kafka topics to be monitored. And add bypass and acknowledgement indicators similar to lclshome.