### PR TITLE
FIX: Ensure kafka messages that indicate removal of an item cause it to be removed from the tree/table

### DIFF
--- a/slam/alarm_tree_model.py
+++ b/slam/alarm_tree_model.py
@@ -201,6 +201,14 @@ class AlarmItemsTreeModel(QAbstractItemModel):
             logger.debug(f'Attempting to remove item not in the tree: {item_path}')
             return
 
-        self.added_paths.remove(item_path)
         item_index = self.getItemIndex(item_path)
+        self.beginRemoveRows(QModelIndex(), item_index, item_index)
+        self.added_paths.remove(item_path)
         del self.nodes[item_index]
+        self.endRemoveRows()
+
+        if len(self.nodes) == 1:
+            # All nodes should be removed at this point, as it is a complete replacement
+            self.beginRemoveRows(QModelIndex(), 0, 0)
+            self.clear()
+            self.endRemoveRows()

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -95,6 +95,8 @@ class AlarmHandlerMainWindow(QMainWindow):
                 self.tree_view_widget.treeModel.update_model(message.key[7:], values)
             else:  # A null message indicates this item should be removed from the tree
                 self.tree_view_widget.treeModel.remove_item(message.key[7:])
+                self.table_view_widget.alarmModel.remove_row(message.key[7:].split('/')[-1])
+                self.table_view_widget.acknowledgedAlarmsModel.remove_row(message.key[7:].split('/')[-1])
         elif key.startswith('command'):
             pass  # Nothing for us to do
         elif values is not None and (len(values) <= 2):

--- a/slam/tests/test_alarm_tree_model.py
+++ b/slam/tests/test_alarm_tree_model.py
@@ -125,9 +125,7 @@ def test_remove_item(tree_model):
     assert len(tree_model.nodes) == 2
 
     tree_model.remove_item('/to/be/removed/TEST:PV')
-    assert len(tree_model.nodes) == 1
-    assert len(tree_model.added_paths) == 1
-
     tree_model.remove_item('/other/pv/OTHER:PV')
+
     assert len(tree_model.nodes) == 0
     assert len(tree_model.added_paths) == 0


### PR DESCRIPTION
Deleted items were still sticking around and being displayed in the tree/table. 