### PR TITLE
ENH: Monitor multiple alarm topics from kafka at the same time

### DIFF
--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -54,7 +54,7 @@ class AlarmTableViewWidget(QWidget):
         self.alarm_proxy_model.setFilterKeyColumn(-1)
         self.alarm_proxy_model.setSourceModel(self.alarmModel)
 
-        self.alarmView.setModel(self.alarm_proxy_model)
+        self.alarmView.setModel(self.alarmModel)
         self.acknowledgedAlarmsView.setModel(self.acknowledgedAlarmsModel)
 
         # The table for alarms which are currently active
@@ -108,6 +108,7 @@ class AlarmTableViewWidget(QWidget):
         self.filter_active_label = QLabel('Filter Active: ')
         self.filter_active_label.setStyleSheet('background-color: orange')
         self.filter_active_label.hide()
+        self.first_filter = True
 
         self.layout.addWidget(self.active_alarms_label)
         self.search_layout = QHBoxLayout()
@@ -126,6 +127,11 @@ class AlarmTableViewWidget(QWidget):
 
     def filter_table(self) -> None:
         """ Filter the table based on the text typed into the filter bar """
+        if self.first_filter:
+            # By delaying setting the proxy model until an actual filter request, performance is improved by a lot
+            # when first loading data into the table
+            self.first_filter = False
+            self.alarmView.setModel(self.alarm_proxy_model)
         self.alarm_proxy_model.setFilterFixedString(self.active_alarm_search_bar.text())
         if self.active_alarm_search_bar.text():
             self.filter_active_label.setText(f'Filter Active: {self.active_alarm_search_bar.text()}')

--- a/slam/kafka_reader.py
+++ b/slam/kafka_reader.py
@@ -11,8 +11,8 @@ class KafkaReader(QObject):
 
     Parameters
     ----------
-    topic_name : str
-        The name of the topic to subscribe to. Will also subscribe to the command topic as well
+    topics : List[str]
+        A list of topics representing the alarm configs to listen to
     bootstrap_servers : List[str]
         A list containing one or more urls for kafka bootstrap servers
     new_message_slot : Callable
@@ -21,10 +21,9 @@ class KafkaReader(QObject):
 
     new_message_signal = Signal(ConsumerRecord)  # Emitted for every new message received
 
-    def __init__(self, topic_name: str, bootstrap_servers: List[str], new_message_slot: Callable):
-        self.topic_name = topic_name
-        self.main_consumer = KafkaConsumer(topic_name,
-                                           f'{topic_name}Command',
+    def __init__(self, topics: List[str], bootstrap_servers: List[str], new_message_slot: Callable):
+        self.topics = topics
+        self.main_consumer = KafkaConsumer(*topics,
                                            bootstrap_servers=bootstrap_servers,
                                            auto_offset_reset='earliest',
                                            enable_auto_commit=False,

--- a/slam_launcher/main.py
+++ b/slam_launcher/main.py
@@ -8,7 +8,7 @@ from slam import AlarmHandlerMainWindow
 
 def main():
     parser = argparse.ArgumentParser(description="SLAC Alarm Manager")
-    parser.add_argument('--topic', help='Kafka alarm topic to listen to')
+    parser.add_argument('--topics', help='Comma separated list of kafka alarm topics to listen to')
     parser.add_argument('--bootstrap-servers',
                         default='localhost:9092',
                         help='Comma separated list of urls for one or more kafka boostrap servers')
@@ -18,10 +18,11 @@ def main():
 
     logging.basicConfig(level=app_args.log.upper())
 
+    topics = app_args.topics.split(',')
     kafka_boostrap_servers = app_args.bootstrap_servers.split(',')
 
     app = QApplication([])
-    main_window = AlarmHandlerMainWindow(app_args.topic, kafka_boostrap_servers)
+    main_window = AlarmHandlerMainWindow(topics, kafka_boostrap_servers)
     main_window.resize(1035, 600)
     main_window.setWindowTitle('SLAC Alarm Manager')
     main_window.show()


### PR DESCRIPTION
-topics is now a comma separated list for what to listen to from kafka. Allows switching between the topics using a combo box in the ui. Fixes an issue where data loading into the table was too slow using a proxy model from the start.