### PR TITLE
MAINT: Refactor the way the alarm tables are created

### DIFF
--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -1,4 +1,4 @@
-import functools
+import enum
 import getpass
 import socket
 from kafka.producer import KafkaProducer
@@ -7,9 +7,16 @@ from qtpy.QtGui import QCursor
 from qtpy.QtWidgets import (QAbstractItemView, QAction, QApplication, QHBoxLayout, QHeaderView, QLabel,
                             QLineEdit, QMenu, QPushButton, QTableView, QVBoxLayout, QWidget)
 from typing import Callable
-from .alarm_item import AlarmSeverity
 from .alarm_table_model import AlarmItemsTableModel
 from .alarm_tree_model import AlarmItemsTreeModel
+
+
+class AlarmTableType(str, enum.Enum):
+    """
+    An enum for the type of alarms this table is displaying.
+    """
+    ACTIVE = 'ACTIVE'
+    ACKNOWLEDGED = 'ACKNOWLEDGED'
 
 
 class AlarmTableViewWidget(QWidget):
@@ -24,30 +31,31 @@ class AlarmTableViewWidget(QWidget):
         The producer for sending state and command updates to the kafka cluster
     topic : str
         The kafka topic to send update messages to
+    table_type: AlarmTableType
+        The type of alarms this table is displaying (active or acknowledged)
     plot_slot : callable
         The function to invoke for plotting a PV
     """
     plot_signal = Signal(str)
 
-    def __init__(self, tree_model: AlarmItemsTreeModel, kafka_producer: KafkaProducer, topic: str, plot_slot: Callable):
+    def __init__(self, tree_model: AlarmItemsTreeModel, kafka_producer: KafkaProducer,
+                 topic: str, table_type: AlarmTableType, plot_slot: Callable):
         super().__init__()
         self.resize(1035, 600)
 
         self.tree_model = tree_model  # We still need the tree hierarchy when dealing with acks at non leaf nodes
         self.kafka_producer = kafka_producer
         self.topic = topic
+        self.table_type = table_type
         self.plot_slot = plot_slot
         self.plot_signal.connect(self.plot_slot)
         self.clipboard = QApplication.clipboard()
 
         self.layout = QVBoxLayout(self)
-        self.active_alarms_label = QLabel('Active Alarms: 0')
-        self.acknowledged_alarms_label = QLabel('Acknowledged Alarms: 0')
+        self.alarm_count_label = QLabel('Active Alarms: 0')
         self.alarmView = QTableView(self)
-        self.acknowledgedAlarmsView = QTableView(self)
 
         self.alarmModel = AlarmItemsTableModel()
-        self.acknowledgedAlarmsModel = AlarmItemsTableModel()
 
         # Using a proxy model allows for filtering based on a search bar
         self.alarm_proxy_model = QSortFilterProxyModel()
@@ -55,7 +63,6 @@ class AlarmTableViewWidget(QWidget):
         self.alarm_proxy_model.setSourceModel(self.alarmModel)
 
         self.alarmView.setModel(self.alarmModel)
-        self.acknowledgedAlarmsView.setModel(self.acknowledgedAlarmsModel)
 
         # The table for alarms which are currently active
         self.alarmView.setProperty("showDropIndicator", False)
@@ -71,46 +78,29 @@ class AlarmTableViewWidget(QWidget):
         self.alarmView.horizontalHeader().setStretchLastSection(True)
         self.alarmView.horizontalHeader().setSectionsMovable(True)
 
-        # The table for alarms which have been acknowledged
-        self.acknowledgedAlarmsView.setProperty("showDropIndicator", False)
-        self.acknowledgedAlarmsView.setDragDropOverwriteMode(False)
-        self.acknowledgedAlarmsView.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.acknowledgedAlarmsView.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.acknowledgedAlarmsView.setCornerButtonEnabled(False)
-        self.acknowledgedAlarmsView.setSortingEnabled(True)
-        self.acknowledgedAlarmsView.verticalHeader().setVisible(False)
-        self.acknowledgedAlarmsView.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
-        for i in range(len(self.acknowledgedAlarmsModel.column_names)):
-            self.acknowledgedAlarmsView.horizontalHeader().resizeSection(i, 150)
-        self.acknowledgedAlarmsView.horizontalHeader().setStretchLastSection(True)
-        self.acknowledgedAlarmsView.horizontalHeader().setSectionsMovable(True)
-
         # The actions which may be taken on an alarm
-        self.active_context_menu = QMenu(self)
-        self.acknowledged_context_menu = QMenu(self)
+        self.alarm_context_menu = QMenu(self)
         self.acknowledge_action = QAction('Acknowledge')
         self.unacknowledge_action = QAction('Unacknowledge')
-        self.active_copy_action = QAction('Copy PV To Clipboard')
-        self.acknowledged_copy_action = QAction('Copy PV To Clipboard')
+        self.copy_action = QAction('Copy PV To Clipboard')
         self.plot_action = QAction('Draw Plot')
         self.acknowledge_action.triggered.connect(self.send_acknowledgement)
         self.unacknowledge_action.triggered.connect(self.send_unacknowledgement)
         self.plot_action.triggered.connect(self.plot_pv)
-        self.active_copy_action.triggered.connect(self.copy_active_alarm_to_clipboard)
-        self.acknowledged_copy_action.triggered.connect(self.copy_acknowledged_alarm_to_clipboard)
+        self.copy_action.triggered.connect(self.copy_alarm_name_to_clipboard)
 
-        self.active_context_menu.addAction(self.acknowledge_action)
-        self.active_context_menu.addAction(self.active_copy_action)
-        self.active_context_menu.addAction(self.plot_action)
-        self.acknowledged_context_menu.addAction(self.unacknowledge_action)
-        self.acknowledged_context_menu.addAction(self.acknowledged_copy_action)
-        self.acknowledged_context_menu.addAction(self.plot_action)
+        if self.table_type is AlarmTableType.ACTIVE:
+            self.alarm_context_menu.addAction(self.acknowledge_action)
+        if self.table_type is AlarmTableType.ACKNOWLEDGED:
+            self.alarm_context_menu.addAction(self.unacknowledge_action)
 
-        self.alarmView.contextMenuEvent = self.active_alarm_context_menu_event
-        self.acknowledgedAlarmsView.contextMenuEvent = self.acknowledged_alarm_context_menu_event
+        self.alarm_context_menu.addAction(self.copy_action)
+        self.alarm_context_menu.addAction(self.plot_action)
+
+        self.alarmView.contextMenuEvent = self.alarm_context_menu_event
 
         # For filtering the alarm table
-        self.active_alarm_search_bar = QLineEdit()
+        self.alarm_filter_bar = QLineEdit()
         self.filter_button = QPushButton('Filter')
         self.filter_button.pressed.connect(self.filter_table)
         self.filter_active_label = QLabel('Filter Active: ')
@@ -118,20 +108,16 @@ class AlarmTableViewWidget(QWidget):
         self.filter_active_label.hide()
         self.first_filter = True
 
-        self.layout.addWidget(self.active_alarms_label)
+        self.layout.addWidget(self.alarm_count_label)
         self.search_layout = QHBoxLayout()
-        self.search_layout.addWidget(self.active_alarm_search_bar)
+        self.search_layout.addWidget(self.alarm_filter_bar)
         self.search_layout.addWidget(self.filter_button)
         self.layout.addLayout(self.search_layout)
         self.layout.addWidget(self.filter_active_label)
         self.layout.addWidget(self.alarmView)
-        self.layout.addWidget(self.acknowledged_alarms_label)
-        self.layout.addWidget(self.acknowledgedAlarmsView)
 
         self.alarmModel.rowsInserted.connect(self.update_counter_label)
         self.alarmModel.rowsRemoved.connect(self.update_counter_label)
-        self.acknowledgedAlarmsModel.rowsInserted.connect(self.update_counter_label)
-        self.acknowledgedAlarmsModel.rowsRemoved.connect(self.update_counter_label)
 
     def filter_table(self) -> None:
         """ Filter the table based on the text typed into the filter bar """
@@ -140,25 +126,23 @@ class AlarmTableViewWidget(QWidget):
             # when first loading data into the table
             self.first_filter = False
             self.alarmView.setModel(self.alarm_proxy_model)
-        self.alarm_proxy_model.setFilterFixedString(self.active_alarm_search_bar.text())
-        if self.active_alarm_search_bar.text():
-            self.filter_active_label.setText(f'Filter Active: {self.active_alarm_search_bar.text()}')
+        self.alarm_proxy_model.setFilterFixedString(self.alarm_filter_bar.text())
+        if self.alarm_filter_bar.text():
+            self.filter_active_label.setText(f'Filter Active: {self.alarm_filter_bar.text()}')
             self.filter_active_label.show()
         else:
             self.filter_active_label.hide()
 
     def update_counter_label(self) -> None:
         """ Update the labels displaying the count of active and acknowledged alarms """
-        self.active_alarms_label.setText(f'Active Alarms: {len(self.alarmModel.alarm_items)}')
-        self.acknowledged_alarms_label.setText(f'Acknowledged Alarms: {len(self.acknowledgedAlarmsModel.alarm_items)}')
+        if self.table_type is AlarmTableType.ACTIVE:
+            self.alarm_count_label.setText(f'Active Alarms: {len(self.alarmModel.alarm_items)}')
+        else:
+            self.alarm_count_label.setText(f'Acknowledged Alarms: {len(self.alarmModel.alarm_items)}')
 
-    def active_alarm_context_menu_event(self, ev: QEvent) -> None:
+    def alarm_context_menu_event(self, ev: QEvent) -> None:
         """ Display the right-click context menu for items in the active alarms table """
-        self.active_context_menu.popup(QCursor.pos())
-
-    def acknowledged_alarm_context_menu_event(self, ev: QEvent) -> None:
-        """ Display the right-click context menu for items in the acknowledged alarms table """
-        self.acknowledged_context_menu.popup(QCursor.pos())
+        self.alarm_context_menu.popup(QCursor.pos())
 
     def plot_pv(self) -> None:
         """ Send off the signal for plotting a PV """
@@ -168,24 +152,13 @@ class AlarmTableViewWidget(QWidget):
             alarm_item = list(self.alarmModel.alarm_items.items())[index.row()][1]
             self.plot_signal.emit(alarm_item.name)
 
-    def copy_active_alarm_to_clipboard(self) -> None:
+    def copy_alarm_name_to_clipboard(self) -> None:
         """ Copy the selected PV to the user's clipboard """
         indices = self.alarmView.selectionModel().selectedRows()
         if len(indices) > 0:
             copy_text = ''
             for index in indices:
                 alarm_item = list(self.alarmModel.alarm_items.items())[index.row()][1]
-                copy_text += alarm_item.name + ' '
-            self.clipboard.setText(copy_text[:-1], mode=self.clipboard.Selection)
-            self.clipboard.setText(copy_text[:-1], mode=self.clipboard.Clipboard)
-
-    def copy_acknowledged_alarm_to_clipboard(self) -> None:
-        """ Copy the selected PV to the user's clipboard """
-        indices = self.acknowledgedAlarmsView.selectionModel().selectedRows()
-        if len(indices) > 0:
-            copy_text = ''
-            for index in indices:
-                alarm_item = list(self.acknowledgedAlarmsModel.alarm_items.items())[index.row()][1]
                 copy_text += alarm_item.name + ' '
             self.clipboard.setText(copy_text[:-1], mode=self.clipboard.Selection)
             self.clipboard.setText(copy_text[:-1], mode=self.clipboard.Clipboard)
@@ -204,31 +177,12 @@ class AlarmTableViewWidget(QWidget):
 
     def send_unacknowledgement(self) -> None:
         """ Send the un-acknowledge action by sending it to the command topic in the kafka cluster """
-        indices = self.acknowledgedAlarmsView.selectedIndexes()
+        indices = self.alarmView.selectedIndexes()
         if len(indices) > 0:
             for index in indices:
-                alarm_item = list(self.acknowledgedAlarmsModel.alarm_items.items())[index.row()][1]
+                alarm_item = list(self.alarmModel.alarm_items.items())[index.row()][1]
                 username = getpass.getuser()
                 hostname = socket.gethostname()
                 self.kafka_producer.send(self.topic + 'Command',
                                          key=f'command:{alarm_item.path}',
                                          value={'user': username, 'host': hostname, 'command': 'unacknowledge'})
-
-    def update_tables(self, name: str, path: str, severity: AlarmSeverity, status: str, time,
-                      value: str, pv_severity: AlarmSeverity, pv_status: str) -> None:
-        """ Update both the active and acknowledged alarm tables when a new alarm state message is received """
-        if status == 'Disabled':
-            self.alarmModel.remove_row(name)
-            self.acknowledgedAlarmsModel.remove_row(name)
-        elif severity in (AlarmSeverity.INVALID_ACK, AlarmSeverity.MAJOR_ACK,
-                          AlarmSeverity.MINOR_ACK, AlarmSeverity.UNDEFINED_ACK):
-            if name in self.alarmModel.alarm_items:
-                self.alarmModel.remove_row(name)
-            self.acknowledgedAlarmsModel.update_row(name, path, severity, status, time, value, pv_severity, pv_status)
-        elif severity == AlarmSeverity.OK:
-            self.alarmModel.remove_row(name)
-            self.acknowledgedAlarmsModel.remove_row(name)
-        else:
-            if name in self.acknowledgedAlarmsModel.alarm_items:
-                self.acknowledgedAlarmsModel.remove_row(name)
-            self.alarmModel.update_row(name, path, severity, status, time, value, pv_severity, pv_status)

--- a/slam/tests/test_alarm_table_view.py
+++ b/slam/tests/test_alarm_table_view.py
@@ -1,55 +1,54 @@
 from ..alarm_item import AlarmItem, AlarmSeverity
-from ..alarm_table_view import AlarmTableViewWidget
+from ..alarm_table_view import AlarmTableType, AlarmTableViewWidget
 from qtpy.QtCore import QEvent, QItemSelectionModel, QModelIndex
 from qtpy.QtWidgets import QTableView
 import pytest
 
 
 @pytest.fixture(scope='function')
-def alarm_table_view(tree_model, mock_kafka_producer):
+def active_alarm_table_view(tree_model, mock_kafka_producer):
     """ Return an empty alarm table view for testing """
-    return AlarmTableViewWidget(tree_model, mock_kafka_producer, 'TEST_TOPIC', lambda x: x)
+    return AlarmTableViewWidget(tree_model, mock_kafka_producer, 'TEST_TOPIC', AlarmTableType.ACTIVE, lambda x: x)
+
+@pytest.fixture(scope='function')
+def acknowledged_alarm_table_view(tree_model, mock_kafka_producer):
+    """ Return an empty alarm table view for testing """
+    return AlarmTableViewWidget(tree_model, mock_kafka_producer, 'TEST_TOPIC', AlarmTableType.ACKNOWLEDGED, lambda x: x)
 
 
-def test_create_and_show(qtbot, alarm_table_view):
+def test_create_and_show(qtbot, active_alarm_table_view):
     """ A simple check that the alarm table view will init and show without any errors """
-    qtbot.addWidget(alarm_table_view)
-    with qtbot.waitExposed(alarm_table_view):
-        alarm_table_view.show()
+    qtbot.addWidget(active_alarm_table_view)
+    with qtbot.waitExposed(active_alarm_table_view):
+        active_alarm_table_view.show()
 
 
-def test_update_counter_label(alarm_item, alarm_table_view):
+def test_update_counter_label(alarm_item, active_alarm_table_view, acknowledged_alarm_table_view):
     """ Verify alarm item counts are updated accurately """
     # Add one active alarm and update the counts. Should be 1 for active and 0 for acknowledged
-    alarm_table_view.alarmModel.append(alarm_item)
-    alarm_table_view.update_counter_label()
-    assert alarm_table_view.active_alarms_label.text() == 'Active Alarms: 1'
-    assert alarm_table_view.acknowledged_alarms_label.text() == 'Acknowledged Alarms: 0'
+    active_alarm_table_view.alarmModel.append(alarm_item)
+    active_alarm_table_view.update_counter_label()
+    assert active_alarm_table_view.alarm_count_label.text() == 'Active Alarms: 1'
 
     # Now add an acknowledged alarm. Counts should now be 1 for both
-    alarm_table_view.acknowledgedAlarmsModel.append(alarm_item)
-    assert alarm_table_view.active_alarms_label.text() == 'Active Alarms: 1'
-    assert alarm_table_view.acknowledged_alarms_label.text() == 'Acknowledged Alarms: 1'
+    acknowledged_alarm_table_view.alarmModel.append(alarm_item)
+    assert acknowledged_alarm_table_view.alarm_count_label.text() == 'Acknowledged Alarms: 1'
 
 
-def test_context_menu_create_and_show(qtbot, alarm_table_view):
+def test_context_menu_create_and_show(qtbot, active_alarm_table_view):
     """ Quick check to confirm that both context menus on this view init and show without any errors """
-    qtbot.addWidget(alarm_table_view)
-    alarm_table_view.active_alarm_context_menu_event(ev=QEvent(QEvent.Type.ContextMenu))
-    with qtbot.waitExposed(alarm_table_view.active_context_menu):
-        alarm_table_view.active_context_menu.show()
-
-    alarm_table_view.acknowledged_alarm_context_menu_event(ev=QEvent(QEvent.Type.ContextMenu))
-    with qtbot.waitExposed(alarm_table_view.acknowledged_context_menu):
-        alarm_table_view.acknowledged_context_menu.show()
+    qtbot.addWidget(active_alarm_table_view)
+    active_alarm_table_view.alarm_context_menu_event(ev=QEvent(QEvent.Type.ContextMenu))
+    with qtbot.waitExposed(active_alarm_table_view.alarm_context_menu):
+        active_alarm_table_view.alarm_context_menu.show()
 
 
-def test_send_acknowledgement(qtbot, monkeypatch, alarm_table_view, mock_kafka_producer):
+def test_send_acknowledgement(qtbot, monkeypatch, active_alarm_table_view, mock_kafka_producer):
     """ Test that when a user acknowledges an alarm, the message send to kafka is as expected """
-    qtbot.addWidget(alarm_table_view)
+    qtbot.addWidget(active_alarm_table_view)
     # Create an alarm with a severity of major
     alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR)
-    alarm_table_view.alarmModel.append(alarm_item)
+    active_alarm_table_view.alarmModel.append(alarm_item)
 
     # Monkeypatch some qt methods to return our alarm as the selected index
     model_index = QModelIndex()
@@ -58,7 +57,7 @@ def test_send_acknowledgement(qtbot, monkeypatch, alarm_table_view, mock_kafka_p
     monkeypatch.setattr(model_index, 'row', lambda: 0)
 
     # Send the acknowledgement, and verify the message we are sending to kafka looks the way we want it to
-    alarm_table_view.send_acknowledgement()
+    active_alarm_table_view.send_acknowledgement()
     # Setting the correct topic, path, and acknowledgement command is all we need to acknowledge an alarm
     assert mock_kafka_producer.topic == 'TEST_TOPICCommand'
     assert mock_kafka_producer.key == 'command:/path/to/TEST:PV'
@@ -66,12 +65,12 @@ def test_send_acknowledgement(qtbot, monkeypatch, alarm_table_view, mock_kafka_p
     assert mock_kafka_producer.values['command'] == 'acknowledge'
 
 
-def test_send_unacknowledgement(qtbot, monkeypatch, alarm_table_view, mock_kafka_producer):
+def test_send_unacknowledgement(qtbot, monkeypatch, acknowledged_alarm_table_view, mock_kafka_producer):
     """ Similar to the send acknowledgment test, except we now deal with the unacknowledge action and table """
-    qtbot.addWidget(alarm_table_view)
+    qtbot.addWidget(acknowledged_alarm_table_view)
     # Create an alarm that has been acknowledged
     alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR_ACK)
-    alarm_table_view.acknowledgedAlarmsModel.append(alarm_item)
+    acknowledged_alarm_table_view.alarmModel.append(alarm_item)
 
     # Monkeypatch some qt methods to return our alarm as the selected index
     model_index = QModelIndex()
@@ -80,44 +79,9 @@ def test_send_unacknowledgement(qtbot, monkeypatch, alarm_table_view, mock_kafka
     monkeypatch.setattr(model_index, 'row', lambda: 0)
 
     # Send the unacknowledgement, and verify the message we are sending to kafka looks the way we want it to
-    alarm_table_view.send_unacknowledgement()
+    acknowledged_alarm_table_view.send_unacknowledgement()
     # Setting the correct topic, path, and acknoledgement command is all we need to acknowledge an alarm
     assert mock_kafka_producer.topic == 'TEST_TOPICCommand'
     assert mock_kafka_producer.key == 'command:/path/to/TEST:PV'
     assert 'command' in mock_kafka_producer.values
     assert mock_kafka_producer.values['command'] == 'unacknowledge'
-
-
-def test_update_tables(qtbot, alarm_table_view):
-    """ Test the various updates that can happen to the alarm table view """
-    qtbot.addWidget(alarm_table_view)
-
-    # First let's add both an active and an acknowledge alarm so we have some test data to work with
-    active_alarm = AlarmItem('ACTIVE:ALARM', path='/path/to/ACTIVE:ALARM', alarm_severity=AlarmSeverity.MAJOR)
-    acknowledged_alarm = AlarmItem('ACK:ALARM', path='/path/to/ACK:ALARM', alarm_severity=AlarmSeverity.MINOR_ACK)
-    alarm_table_view.alarmModel.append(active_alarm)
-    alarm_table_view.acknowledgedAlarmsModel.append(acknowledged_alarm)
-
-    # Start with sending a "disabled" update for the active alarm. This means the user has disabled this
-    # alarm and it should no longer be monitored.
-    alarm_table_view.update_tables('ACTIVE:ALARM', '', AlarmSeverity.MAJOR, 'Disabled',
-                                   None, '', AlarmSeverity.MAJOR, '')
-    assert len(alarm_table_view.alarmModel.alarm_items) == 0  # Remove as expected
-    assert len(alarm_table_view.acknowledgedAlarmsModel.alarm_items) == 1  # Unaffected
-
-    # Now put it back, and simulate a user acknowledging the alarm
-    alarm_table_view.alarmModel.append(active_alarm)
-    # The MAJOR_ACK indicates an acknowledgment action
-    alarm_table_view.update_tables('ACTIVE:ALARM', '', AlarmSeverity.MAJOR_ACK, '', None, '', AlarmSeverity.MAJOR, '')
-    assert len(alarm_table_view.alarmModel.alarm_items) == 0  # Again the active alarm was removed
-    assert len(alarm_table_view.acknowledgedAlarmsModel.alarm_items) == 2  # But this time added to acknowledged alarms
-
-    # Now simulate the alarm returning to an OK state, this should clear the alarm since it is both acknowledged and OK
-    alarm_table_view.update_tables('ACTIVE:ALARM', '', AlarmSeverity.OK, '', None, '', AlarmSeverity.OK, '')
-    assert len(alarm_table_view.alarmModel.alarm_items) == 0  # This should not have changed
-    assert len(alarm_table_view.acknowledgedAlarmsModel.alarm_items) == 1  # But this should have cleared one alarm now
-
-    # And finally update the severity of the acknowledged alarm. This change of state will set it back to being active
-    alarm_table_view.update_tables('ACK:ALARM', '', AlarmSeverity.MAJOR, '', None, '', AlarmSeverity.MAJOR, '')
-    assert len(alarm_table_view.alarmModel.alarm_items) == 1  # This alarm is now activate again
-    assert len(alarm_table_view.acknowledgedAlarmsModel.alarm_items) == 0  # And it was moved out of this table

--- a/slam_launcher/main.py
+++ b/slam_launcher/main.py
@@ -23,7 +23,7 @@ def main():
 
     app = QApplication([])
     main_window = AlarmHandlerMainWindow(topics, kafka_boostrap_servers)
-    main_window.resize(1035, 600)
+    main_window.resize(1920, 1080)
     main_window.setWindowTitle('SLAC Alarm Manager')
     main_window.show()
 


### PR DESCRIPTION
Allows for better use of the splitter widget, and is just a better way of doing this in general.