### PR TITLE
ENH: Send updates to kafka for each path the PV is part of

### DIFF
--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -174,9 +174,10 @@ class AlarmTableViewWidget(QWidget):
                 alarm_item = list(self.alarmModel.alarm_items.items())[index.row()][1]
                 username = getpass.getuser()
                 hostname = socket.gethostname()
-                self.kafka_producer.send(self.topic + 'Command',
-                                         key=f'command:{alarm_item.path}',
-                                         value={'user': username, 'host': hostname, 'command': 'acknowledge'})
+                for alarm_path in self.tree_model.added_paths[alarm_item.name]:
+                    self.kafka_producer.send(self.topic + 'Command',
+                                             key=f'command:{alarm_path}',
+                                             value={'user': username, 'host': hostname, 'command': 'acknowledge'})
 
     def send_unacknowledgement(self) -> None:
         """ Send the un-acknowledge action by sending it to the command topic in the kafka cluster """
@@ -186,6 +187,7 @@ class AlarmTableViewWidget(QWidget):
                 alarm_item = list(self.alarmModel.alarm_items.items())[index.row()][1]
                 username = getpass.getuser()
                 hostname = socket.gethostname()
-                self.kafka_producer.send(self.topic + 'Command',
-                                         key=f'command:{alarm_item.path}',
-                                         value={'user': username, 'host': hostname, 'command': 'unacknowledge'})
+                for alarm_path in self.tree_model.added_paths[alarm_item.name]:
+                    self.kafka_producer.send(self.topic + 'Command',
+                                             key=f'command:{alarm_path}',
+                                             value={'user': username, 'host': hostname, 'command': 'unacknowledge'})

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -162,9 +162,10 @@ class AlarmTreeViewWidget(QWidget):
             alarm_item = self.treeModel.getItem(index)
             username = getpass.getuser()
             hostname = socket.gethostname()
-            self.kafka_producer.send(self.topic + 'Command',
-                                     key=f'command:{alarm_item.path}',
-                                     value={'user': username, 'host': hostname, 'command': 'acknowledge'})
+            for alarm_path in self.treeModel.added_paths[alarm_item.name]:
+                self.kafka_producer.send(self.topic + 'Command',
+                                         key=f'command:{alarm_path}',
+                                         value={'user': username, 'host': hostname, 'command': 'acknowledge'})
 
     def send_unacknowledgement(self) -> None:
         """ Send the un-acknowledge action by sending it to the command topic in the kafka cluster """
@@ -174,9 +175,10 @@ class AlarmTreeViewWidget(QWidget):
             alarm_item = self.treeModel.getItem(index)
             username = getpass.getuser()
             hostname = socket.gethostname()
-            self.kafka_producer.send(self.topic + 'Command',
-                                     key=f'command:{alarm_item.path}',
-                                     value={'user': username, 'host': hostname, 'command': 'unacknowledge'})
+            for alarm_path in self.treeModel.added_paths[alarm_item.name]:
+                self.kafka_producer.send(self.topic + 'Command',
+                                         key=f'command:{alarm_path}',
+                                         value={'user': username, 'host': hostname, 'command': 'unacknowledge'})
 
     def enable_alarm(self) -> None:
         """ Enable the selected alarm. If the selected item is a parent node, enable all its children """
@@ -187,21 +189,23 @@ class AlarmTreeViewWidget(QWidget):
             username = getpass.getuser()
             hostname = socket.gethostname()
             if alarm_item.is_leaf() and not alarm_item.is_enabled():
-                self.kafka_producer.send(self.topic,
-                                         key=f'config:{alarm_item.path}',
-                                         value={'user': username, 'host': hostname,
-                                                'description': alarm_item.description, 'enabled': True,
-                                                'latching': alarm_item.latching,
-                                                'annunciating': alarm_item.annunciating})
+                for alarm_path in self.treeModel.added_paths[alarm_item.name]:
+                    self.kafka_producer.send(self.topic,
+                                             key=f'config:{alarm_path}',
+                                             value={'user': username, 'host': hostname,
+                                                    'description': alarm_item.description, 'enabled': True,
+                                                    'latching': alarm_item.latching,
+                                                    'annunciating': alarm_item.annunciating})
             elif not alarm_item.is_leaf():
                 all_leaf_nodes = self.treeModel.get_all_leaf_nodes(alarm_item)
                 for leaf in all_leaf_nodes:
                     if not leaf.is_enabled():
-                        self.kafka_producer.send(self.topic,
-                                                 key=f'config:{leaf.path}',
-                                                 value={'user': username, 'host': hostname,
-                                                        'description': leaf.description, 'enabled': True,
-                                                        'latching': leaf.latching, 'annunciating': leaf.annunciating})
+                        for alarm_path in self.treeModel.added_paths[leaf.name]:
+                            self.kafka_producer.send(self.topic,
+                                                     key=f'config:{alarm_path}',
+                                                     value={'user': username, 'host': hostname,
+                                                            'description': leaf.description, 'enabled': True,
+                                                            'latching': leaf.latching, 'annunciating': leaf.annunciating})
 
     def disable_alarm(self) -> None:
         """ Disable the selected alarm. If the selected item is a parent node, disable all its children """
@@ -212,18 +216,20 @@ class AlarmTreeViewWidget(QWidget):
             username = getpass.getuser()
             hostname = socket.gethostname()
             if alarm_item.is_leaf() and alarm_item.is_enabled():
-                self.kafka_producer.send(self.topic,
-                                         key=f'config:{alarm_item.path}',
-                                         value={'user': username, 'host': hostname,
-                                                'description': alarm_item.description, 'enabled': False,
-                                                'latching': alarm_item.latching,
-                                                'annunciating': alarm_item.annunciating})
+                for alarm_path in self.treeModel.added_paths[alarm_item.name]:
+                    self.kafka_producer.send(self.topic,
+                                             key=f'config:{alarm_path}',
+                                             value={'user': username, 'host': hostname,
+                                                    'description': alarm_item.description, 'enabled': False,
+                                                    'latching': alarm_item.latching,
+                                                    'annunciating': alarm_item.annunciating})
             elif not alarm_item.is_leaf():
                 all_leaf_nodes = self.treeModel.get_all_leaf_nodes(alarm_item)
                 for leaf in all_leaf_nodes:
                     if leaf.is_enabled():
-                        self.kafka_producer.send(self.topic,
-                                                 key=f'config:{leaf.path}',
-                                                 value={'user': username, 'host': hostname,
-                                                        'description': leaf.description, 'enabled': False,
-                                                        'latching': leaf.latching, 'annunciating': leaf.annunciating})
+                        for alarm_path in self.treeModel.added_paths[leaf.name]:
+                            self.kafka_producer.send(self.topic,
+                                                     key=f'config:{alarm_path}',
+                                                     value={'user': username, 'host': hostname,
+                                                            'description': leaf.description, 'enabled': False,
+                                                            'latching': leaf.latching, 'annunciating': leaf.annunciating})

--- a/slam/tests/test_alarm_table_view.py
+++ b/slam/tests/test_alarm_table_view.py
@@ -49,6 +49,7 @@ def test_send_acknowledgement(qtbot, monkeypatch, active_alarm_table_view, mock_
     # Create an alarm with a severity of major
     alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR)
     active_alarm_table_view.alarmModel.append(alarm_item)
+    active_alarm_table_view.tree_model.added_paths['TEST:PV'] = ['/path/to/TEST:PV']
 
     # Monkeypatch some qt methods to return our alarm as the selected index
     model_index = QModelIndex()
@@ -71,6 +72,7 @@ def test_send_unacknowledgement(qtbot, monkeypatch, acknowledged_alarm_table_vie
     # Create an alarm that has been acknowledged
     alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR_ACK)
     acknowledged_alarm_table_view.alarmModel.append(alarm_item)
+    acknowledged_alarm_table_view.tree_model.added_paths['TEST:PV'] = ['/path/to/TEST:PV']
 
     # Monkeypatch some qt methods to return our alarm as the selected index
     model_index = QModelIndex()

--- a/slam/tests/test_alarm_tree_view.py
+++ b/slam/tests/test_alarm_tree_view.py
@@ -56,6 +56,7 @@ def test_send_acknowledgement(qtbot, monkeypatch, alarm_tree_view, mock_kafka_pr
     indices = [model_index]
     monkeypatch.setattr(alarm_tree_view.tree_view, 'selectedIndexes', lambda: indices)
     monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
+    alarm_tree_view.treeModel.added_paths['TEST:PV'] = ['/path/to/TEST:PV']
 
     alarm_tree_view.send_acknowledgement()
     # Setting the correct topic, path, and acknowledgement command is all we need to acknowledge an alarm
@@ -76,6 +77,7 @@ def test_send_unacknowledgement(qtbot, monkeypatch, alarm_tree_view, mock_kafka_
     indices = [model_index]
     monkeypatch.setattr(alarm_tree_view.tree_view, 'selectedIndexes', lambda: indices)
     monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
+    alarm_tree_view.treeModel.added_paths['TEST:PV'] = ['/path/to/TEST:PV']
 
     alarm_tree_view.send_unacknowledgement()
     # Setting the correct topic, path, and acknowledgement command is all we need to acknowledge an alarm
@@ -94,6 +96,7 @@ def test_enable_alarm(qtbot, monkeypatch, alarm_item, alarm_tree_view, mock_kafk
     alarm_item.enabled = False  # Disable the alarm so we can enable it later
     monkeypatch.setattr(alarm_tree_view.tree_view, 'selectedIndexes', lambda: indices)
     monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
+    alarm_tree_view.treeModel.added_paths['TEST:PV:ONE'] = ['/ROOT/SECTOR_ONE/TEST:PV:ONE']
 
     alarm_tree_view.enable_alarm()
     assert mock_kafka_producer.topic == 'TEST_TOPIC'
@@ -111,6 +114,7 @@ def test_disable_alarm(qtbot, monkeypatch, alarm_item, alarm_tree_view, mock_kaf
     alarm_item.description = 'Test Alarm'
     monkeypatch.setattr(alarm_tree_view.tree_view, 'selectedIndexes', lambda: indices)
     monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
+    alarm_tree_view.treeModel.added_paths['TEST:PV:ONE'] = ['/ROOT/SECTOR_ONE/TEST:PV:ONE']
 
     alarm_tree_view.disable_alarm()
     assert mock_kafka_producer.topic == 'TEST_TOPIC'


### PR DESCRIPTION
Follow-up to #31 to send multiple updates to kafka when a PV which appears multiple times in the tree is updated. This will allow all clients which read from kafka to see all updates.