### PR TITLE
ENH: Update pydm plugin to support multiple kafka topics

### DIFF
--- a/slam/tests/test_alarm_plugin.py
+++ b/slam/tests/test_alarm_plugin.py
@@ -32,7 +32,7 @@ def test_process_message(mock_record, severity_from_kafka, signal_to_send):
 
     # Setup the alarm plugin and an associated connection
     alarm_plugin = AlarmPlugin()
-    alarm_plugin.kafka_topic = 'test_topic'
+    alarm_plugin.kafka_topics = ['test_topic']
     alarm_plugin.alarm_severities = {}
     alarm_channel = PyDMChannel()
     alarm_connection = Connection(alarm_channel, 'pva://TEST:ADDRESS')


### PR DESCRIPTION
The plugin will now accept a list of topics to monitor and send updates to widgets about. Also will no longer display acknowledged alarms as active. But the downside is they don't display as anything out of the ordinary at all. This may change in the future.