### PR TITLE
FIX: Properly send the (un)/acknowledge command when done at a non-leaf node

### DIFF
--- a/slam/alarm_item.py
+++ b/slam/alarm_item.py
@@ -137,6 +137,11 @@ class AlarmItem(QObject):
         else:
             logger.error(f'Enabled status for alarm: {self.path} is set to a bad value: {self.enabled}')
 
+    def is_in_active_alarm_state(self) -> bool:
+        """ A convenience method for returning whether or not this item is actively in an alarm state """
+        return self.alarm_severity in (AlarmSeverity.MINOR, AlarmSeverity.MAJOR,
+                                       AlarmSeverity.INVALID, AlarmSeverity.UNDEFINED)
+
     def display_color(self, severity) -> QBrush:
         """
         Return a QBrush with the appropriate color for drawing this alarm based on severity

--- a/slam/tests/test_alarm_item.py
+++ b/slam/tests/test_alarm_item.py
@@ -15,6 +15,22 @@ def test_is_leaf():
     assert not alarm_root.is_leaf()
 
 
+@pytest.mark.parametrize('alarm_severity, expected_state',
+                         [(AlarmSeverity.MINOR, True),
+                          (AlarmSeverity.MAJOR, True),
+                          (AlarmSeverity.INVALID, True),
+                          (AlarmSeverity.UNDEFINED, True),
+                          (AlarmSeverity.MINOR_ACK, False),
+                          (AlarmSeverity.MAJOR_ACK, False),
+                          (AlarmSeverity.INVALID_ACK, False),
+                          (AlarmSeverity.UNDEFINED_ACK, False)])
+def test_is_in_activate_alarm_state(alarm_severity, expected_state):
+    """ Confirm that the alarm item correctly reports whether or not it is in an active alarm state """
+    alarm_item = AlarmItem('TEST:PV')
+    alarm_item.alarm_severity = alarm_severity
+    assert alarm_item.is_in_active_alarm_state() == expected_state
+
+
 def test_is_enabled():
     """ Verify the various methods of indicating an alarm item is enabled work properly """
     alarm_item = AlarmItem('TEST:PV')


### PR DESCRIPTION
When acknowledging or unacknowledging and alarm at a non-leaf node in the alarm tree, will now send that action to the command topic separate for every active alarm along the path instead of only at the top level item acted upon. This will ensure clients (like the PyDM plugin) will correctly receive the state of every alarm along the path.

Added test for new method.