### PR TITLE
FIX: Set kafka topic list correctly in the pydm plugin

### DIFF
--- a/pydm_alarm_plugin/alarm_plugin.py
+++ b/pydm_alarm_plugin/alarm_plugin.py
@@ -79,10 +79,10 @@ class AlarmPlugin(PyDMPlugin):
             return
 
         self.alarm_severities = dict()  # Mapping from alarm name to current alarm severity
-        self.kafka_reader = KafkaReader(kafka_topics.split(','),
+        self.kafka_topics = kafka_topics.split(',')
+        self.kafka_reader = KafkaReader(self.kafka_topics,
                                         kafka_bootstrap_servers.split(','),
                                         self.process_message)
-        self.kafka_topics = kafka_topics
         self.processing_thread = QThread()
         self.kafka_reader.moveToThread(self.processing_thread)
         self.processing_thread.started.connect(self.kafka_reader.run)


### PR DESCRIPTION
Missed this when adding support for multiple topics causing top level summaries to be ignored