### PR TITLE
FIX: Get alarm filter to work properly

### DIFF
--- a/slam/alarm_item.py
+++ b/slam/alarm_item.py
@@ -137,6 +137,11 @@ class AlarmItem(QObject):
         else:
             logger.error(f'Enabled status for alarm: {self.path} is set to a bad value: {self.enabled}')
 
+    def is_acknowledged(self) -> bool:
+        """ A convenience method for returning whether or not this item has been acknolwedged """
+        return self.alarm_severity in (AlarmSeverity.MINOR_ACK, AlarmSeverity.MAJOR_ACK,
+                                       AlarmSeverity.INVALID_ACK, AlarmSeverity.UNDEFINED_ACK)
+
     def is_in_active_alarm_state(self) -> bool:
         """ A convenience method for returning whether or not this item is actively in an alarm state """
         return self.alarm_severity in (AlarmSeverity.MINOR, AlarmSeverity.MAJOR,
@@ -199,6 +204,12 @@ class AlarmItem(QObject):
     def column_count(self) -> int:
         """ Return the column count of this item """
         return 1
+
+    def to_config_dict(self) -> Dict[str, any]:
+        """ Dump the current values of the alarm item into a dict that can be sent as a kafka alarm config message """
+        return {'description': self.description, 'guidance': self.guidance, 'displays': self.displays,
+                'commands': self.commands, 'enabled': self.enabled, 'latching': self.latching,
+                'annunciating' : self.annunciating, 'delta': self.delay, 'filter': self.alarm_filter}
 
     def __repr__(self) -> str:
         return f'AlarmItem("{self.name}", {repr(self.path)}, {str(self.alarm_severity)}, {repr(self.alarm_status)}, '\

--- a/slam/alarm_item.py
+++ b/slam/alarm_item.py
@@ -67,6 +67,8 @@ class AlarmItem(QObject):
     enabled : Union[bool, str], optional
         Whether or not this alarm is enabled. A bool in the simple case, a str here will also mean
         disabled, with the str being the date-time it should automatically re-enable.
+    filtered: bool
+        If true, this alarm is disabled via a filter rule, false otherwise.
     latching : bool, optional
         If set to true, this alarm will remain at the highest severity level it attains even if the PV it is monitoring
         returns to a lower severity level. If false, it will stay in sync with its associated PV.
@@ -90,6 +92,7 @@ class AlarmItem(QObject):
                  displays: Optional[List[Dict]] = None,
                  commands: Optional[List[Dict]] = None,
                  enabled: Optional[Union[bool, str]] = True,
+                 filtered: Optional[bool] = False,
                  latching: Optional[bool] = False,
                  annunciating: Optional[bool] = False,
                  delay: Optional[int] = None,
@@ -111,11 +114,14 @@ class AlarmItem(QObject):
         self.commands = commands
         if enabled is None:  # Protect against setting it explicitly to None
             enabled = True
+        if filtered is None:
+            filtered = False
         if latching is None:
             latching = False
         if annunciating is None:
             annunciating = False
         self.enabled = enabled
+        self.filtered = filtered
         self.latching = latching
         self.annunciating = annunciating
         self.delay = delay
@@ -127,6 +133,8 @@ class AlarmItem(QObject):
 
     def is_enabled(self) -> bool:
         """ A convenience method for checking the enabled state of the alarm """
+        if self.filtered:
+            return False
         if type(self.enabled) is bool:
             return self.enabled
         elif type(self.enabled) is str:
@@ -215,4 +223,4 @@ class AlarmItem(QObject):
         return f'AlarmItem("{self.name}", {repr(self.path)}, {str(self.alarm_severity)}, {repr(self.alarm_status)}, '\
                f'{repr(self.alarm_time)}, {repr(self.alarm_value)}, {str(self.pv_severity)}, {repr(self.pv_status)}, '\
                f'{repr(self.description)}, {repr(self.guidance)}, {repr(self.displays)}, {repr(self.commands)}, '\
-               f'{self.enabled}, {self.latching}, {self.annunciating}, {self.delay}, {repr(self.alarm_filter)})'
+               f'{self.enabled}, {self.filtered}, {self.latching}, {self.annunciating}, {self.delay}, {repr(self.alarm_filter)})'

--- a/slam/alarm_tree_model.py
+++ b/slam/alarm_tree_model.py
@@ -49,7 +49,7 @@ class AlarmItemsTreeModel(QAbstractItemModel):
                 # Set an indication there is a bypassed alarm somewhere underneath this top level summary
                 all_leaf_nodes = self.get_all_leaf_nodes(alarm_item)
                 for node in all_leaf_nodes:
-                    if not node.enabled:
+                    if not node.is_enabled():
                         bypass_indicator = ' *'
                         break
             if not alarm_item.is_enabled():
@@ -143,10 +143,9 @@ class AlarmItemsTreeModel(QAbstractItemModel):
             item_to_update.pv_severity = pv_severity
             item_to_update.pv_status = pv_status
             if status == 'Disabled':
-                if item_to_update.enabled and type(item_to_update.enabled) is not str:
-                    item_to_update.enabled = False
-            elif status == 'OK':
-                item_to_update.enabled = True
+                item_to_update.filtered = True
+            elif item_to_update.filtered:
+                item_to_update.filtered = False
         self.layoutChanged.emit()
 
     def update_model(self, item_path: str, values: dict) -> None:

--- a/slam/tests/test_alarm_tree_model.py
+++ b/slam/tests/test_alarm_tree_model.py
@@ -76,15 +76,15 @@ def test_update_item(tree_model):
     assert tree_model.nodes[0].pv_severity == AlarmSeverity.MINOR
     assert tree_model.nodes[0].pv_status == 'alarm_status'
 
-    # Send a disable update message, verify the alarm gets marked disabled
+    # Send a disable update message, verify the alarm gets marked filtered
     tree_model.update_item('TEST:PV', '/path/to/TEST:PV', AlarmSeverity.MINOR, 'Disabled', None, 'FAULT',
                            AlarmSeverity.MINOR, 'alarm_status')
-    assert not tree_model.nodes[0].enabled
+    assert tree_model.nodes[0].filtered
 
     # And then send a message re-enabling the alarm and verify it is marked enabled again
     tree_model.update_item('TEST:PV', '/path/to/TEST:PV', AlarmSeverity.MINOR, 'OK', None, 'FAULT',
                            AlarmSeverity.MINOR, 'alarm_status')
-    assert tree_model.nodes[0].enabled
+    assert not tree_model.nodes[0].filtered
 
 
 def test_update_model(tree_model):

--- a/slam/tests/test_alarm_tree_view.py
+++ b/slam/tests/test_alarm_tree_view.py
@@ -45,11 +45,15 @@ def test_tree_menu(qtbot, monkeypatch, alarm_tree_view):
         alarm_tree_view.context_menu.show()
 
 
-def test_send_acknowledgement(qtbot, monkeypatch, alarm_tree_view, mock_kafka_producer):
-    """ Test that when a user acknowledges an alarm from the tree, the message sent to kafka is correct """
+@pytest.mark.parametrize('acknowledged', [False, True])
+def test_acknowledge_action(qtbot, monkeypatch, alarm_tree_view, mock_kafka_producer, acknowledged):
+    """ Test that when a user acks or un-acks an alarm from the tree, the message sent to kafka is correct """
     qtbot.addWidget(alarm_tree_view)
-    # Create an alarm with a severity of major
-    alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR)
+    # Create an alarm with an acknowledged state opposite to what we want to set
+    if acknowledged:
+        alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR)
+    else:
+        alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR_ACK)
 
     # Monkeypatch some qt methods to return our alarm as the selected index
     model_index = QModelIndex()
@@ -58,67 +62,32 @@ def test_send_acknowledgement(qtbot, monkeypatch, alarm_tree_view, mock_kafka_pr
     monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
     alarm_tree_view.treeModel.added_paths['TEST:PV'] = ['/path/to/TEST:PV']
 
-    alarm_tree_view.send_acknowledgement()
+    alarm_tree_view.send_action(acknowledged=acknowledged)
     # Setting the correct topic, path, and acknowledgement command is all we need to acknowledge an alarm
     assert mock_kafka_producer.topic == 'TEST_TOPICCommand'
     assert mock_kafka_producer.key == 'command:/path/to/TEST:PV'
     assert 'command' in mock_kafka_producer.values
-    assert mock_kafka_producer.values['command'] == 'acknowledge'
+    if acknowledged:
+        assert mock_kafka_producer.values['command'] == 'acknowledge'
+    else:
+        assert mock_kafka_producer.values['command'] == 'unacknowledge'
 
 
-def test_send_unacknowledgement(qtbot, monkeypatch, alarm_tree_view, mock_kafka_producer):
-    """ Test than when a user unacknowledges an alarm from the tree, the message sent to kafka is correct """
-    qtbot.addWidget(alarm_tree_view)
-    # Create an alarm with a severity of major ack
-    alarm_item = AlarmItem('TEST:PV', path='/path/to/TEST:PV', alarm_severity=AlarmSeverity.MAJOR_ACK)
-
-    # Monkeypatch some qt methods to return our alarm as the selected index
-    model_index = QModelIndex()
-    indices = [model_index]
-    monkeypatch.setattr(alarm_tree_view.tree_view, 'selectedIndexes', lambda: indices)
-    monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
-    alarm_tree_view.treeModel.added_paths['TEST:PV'] = ['/path/to/TEST:PV']
-
-    alarm_tree_view.send_unacknowledgement()
-    # Setting the correct topic, path, and acknowledgement command is all we need to acknowledge an alarm
-    assert mock_kafka_producer.topic == 'TEST_TOPICCommand'
-    assert mock_kafka_producer.key == 'command:/path/to/TEST:PV'
-    assert 'command' in mock_kafka_producer.values
-    assert mock_kafka_producer.values['command'] == 'unacknowledge'
-
-
-def test_enable_alarm(qtbot, monkeypatch, alarm_item, alarm_tree_view, mock_kafka_producer):
-    """ Test that when a user enables an alarm from the tree, the message sent to kafka is correct """
+@pytest.mark.parametrize('enabled', [False, True])
+def test_enable_disable_action(qtbot, monkeypatch, alarm_item, alarm_tree_view, mock_kafka_producer, enabled):
+    """ Test that when a user enables or disables an alarm from the tree, the message sent to kafka is correct """
     qtbot.addWidget(alarm_tree_view)
     model_index = QModelIndex()
     indices = [model_index]
     alarm_item.description = 'Test Alarm'
-    alarm_item.enabled = False  # Disable the alarm so we can enable it later
+    alarm_item.enabled = not enabled  # Set it to the opposite of the action we want to take
     monkeypatch.setattr(alarm_tree_view.tree_view, 'selectedIndexes', lambda: indices)
     monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
     alarm_tree_view.treeModel.added_paths['TEST:PV:ONE'] = ['/ROOT/SECTOR_ONE/TEST:PV:ONE']
 
-    alarm_tree_view.enable_alarm()
+    alarm_tree_view.send_action(enabled=enabled)
     assert mock_kafka_producer.topic == 'TEST_TOPIC'
     assert mock_kafka_producer.key == 'config:/ROOT/SECTOR_ONE/TEST:PV:ONE'
     assert mock_kafka_producer.values['description'] == 'Test Alarm'
-    assert mock_kafka_producer.values['enabled']
-    assert not mock_kafka_producer.values['latching']
-
-
-def test_disable_alarm(qtbot, monkeypatch, alarm_item, alarm_tree_view, mock_kafka_producer):
-    """ Test that when a user disables an alarm from the tree, the message sent to kafka is correct """
-    qtbot.addWidget(alarm_tree_view)
-    model_index = QModelIndex()
-    indices = [model_index]
-    alarm_item.description = 'Test Alarm'
-    monkeypatch.setattr(alarm_tree_view.tree_view, 'selectedIndexes', lambda: indices)
-    monkeypatch.setattr(alarm_tree_view.treeModel, 'getItem', lambda x: alarm_item)
-    alarm_tree_view.treeModel.added_paths['TEST:PV:ONE'] = ['/ROOT/SECTOR_ONE/TEST:PV:ONE']
-
-    alarm_tree_view.disable_alarm()
-    assert mock_kafka_producer.topic == 'TEST_TOPIC'
-    assert mock_kafka_producer.key == 'config:/ROOT/SECTOR_ONE/TEST:PV:ONE'
-    assert mock_kafka_producer.values['description'] == 'Test Alarm'
-    assert not mock_kafka_producer.values['enabled']
+    assert mock_kafka_producer.values['enabled'] == enabled
     assert not mock_kafka_producer.values['latching']


### PR DESCRIPTION
Create a new `filtered` property that is separate from the `enabled` one. Kafka `state` messages will affect this new one, `config` messages will continue to toggle the `enabled` status. Cleanup a bunch of unnecessary code duplication.