### PR TITLE
ENH: Add user permissions

### DIFF
--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import (QAbstractItemView, QAction, QApplication, QHBoxLayou
 from typing import Callable
 from .alarm_table_model import AlarmItemsTableModel
 from .alarm_tree_model import AlarmItemsTreeModel
+from .permissions import UserAction, can_take_action
 
 
 class AlarmTableType(str, enum.Enum):
@@ -169,6 +170,9 @@ class AlarmTableViewWidget(QWidget):
 
     def send_acknowledgement(self) -> None:
         """ Send the acknowledge action by sending it to the command topic in the kafka cluster """
+        if not can_take_action(UserAction.ACKNOWLEDGE, log_warning=True):
+            return
+
         indices = self.alarmView.selectionModel().selectedRows()
         if len(indices) > 0:
             for index in indices:
@@ -182,6 +186,9 @@ class AlarmTableViewWidget(QWidget):
 
     def send_unacknowledgement(self) -> None:
         """ Send the un-acknowledge action by sending it to the command topic in the kafka cluster """
+        if not can_take_action(UserAction.ACKNOWLEDGE, log_warning=True):
+            return
+
         indices = self.alarmView.selectionModel().selectedRows()
         if len(indices) > 0:
             for index in indices:

--- a/slam/permissions.py
+++ b/slam/permissions.py
@@ -36,23 +36,29 @@ class UserAction(enum.Enum):
     UPDATE_CONFIG = 'update-config'
 
 
-user_permission = UserPermission.READ_ONLY
+__user_permission = UserPermission.ADMIN
 
 
 def can_take_action(action: UserAction, log_warning=False) -> bool:
     """ Return True if the user can take the input action, False otherwise """
-    if action is UserAction.ACKNOWLEDGE and user_permission == UserPermission.READ_ONLY:
+    if action is UserAction.ACKNOWLEDGE and __user_permission == UserPermission.READ_ONLY:
         if log_warning:
             logger.warning(' Cannot take acknowledge action, permissions are currently set to read-only')
         return False
-    elif action is UserAction.ENABLE and user_permission < UserPermission.ADMIN:
+    elif action is UserAction.ENABLE and __user_permission < UserPermission.ADMIN:
         if log_warning:
             logger.warning(f' Cannot take enable/disable action, requires alarm admin permissions, '
-                           f'currently set to {user_permission.value}')
+                           f'currently set to {__user_permission.value}')
         return False
-    elif action is UserAction.UPDATE_CONFIG and user_permission < UserPermission.ADMIN:
+    elif action is UserAction.UPDATE_CONFIG and __user_permission < UserPermission.ADMIN:
         if log_warning:
             logger.warning(f' Cannot update config, requires alarm admin permissions, '
-                           f'currently set to: {user_permission.value}')
+                           f'currently set to: {__user_permission.value}')
         return False
     return True
+
+
+def set_user_permission(permission: UserPermission) -> None:
+    """ Set the permission determining what the user is allowed to do """
+    global __user_permission
+    __user_permission = permission

--- a/slam/permissions.py
+++ b/slam/permissions.py
@@ -1,0 +1,58 @@
+import enum
+import logging
+from functools import total_ordering
+
+""" 
+A file for dealing with permissions for actions that users are allowed to take. This file is intentionally
+as simple as possible at the moment since there is currently no notion of individual user accounts for using this
+application. Permissions are set on application startup.
+"""
+
+logger = logging.getLogger(__name__)
+
+
+@total_ordering
+class UserPermission(enum.Enum):
+    """
+    An enum for the values that an alarm severity can take on. Not inheriting from str so permission
+    based comparisons can be done.
+    """
+    READ_ONLY = 'read-only'
+    OPERATOR = 'operator'
+    ADMIN = 'admin'
+
+    def __lt__(self, other):
+        """ The order in which they are defined is in order of increasing ability to take action """
+        if self.__class__ is other.__class__:
+            values = [e for e in UserPermission]
+            return values.index(self) < values.index(other)
+        return NotImplemented
+
+
+class UserAction(enum.Enum):
+    """ An enum for the actions available to the user """
+    ACKNOWLEDGE = 'acknowledge'
+    ENABLE = 'enable'
+    UPDATE_CONFIG = 'update-config'
+
+
+user_permission = UserPermission.READ_ONLY
+
+
+def can_take_action(action: UserAction, log_warning=False) -> bool:
+    """ Return True if the user can take the input action, False otherwise """
+    if action is UserAction.ACKNOWLEDGE and user_permission == UserPermission.READ_ONLY:
+        if log_warning:
+            logger.warning(' Cannot take acknowledge action, permissions are currently set to read-only')
+        return False
+    elif action is UserAction.ENABLE and user_permission < UserPermission.ADMIN:
+        if log_warning:
+            logger.warning(f' Cannot take enable/disable action, requires alarm admin permissions, '
+                           f'currently set to {user_permission.value}')
+        return False
+    elif action is UserAction.UPDATE_CONFIG and user_permission < UserPermission.ADMIN:
+        if log_warning:
+            logger.warning(f' Cannot update config, requires alarm admin permissions, '
+                           f'currently set to: {user_permission.value}')
+        return False
+    return True

--- a/slam/tests/test_permissions.py
+++ b/slam/tests/test_permissions.py
@@ -1,0 +1,19 @@
+import pytest
+from ..permissions import UserAction, UserPermission, can_take_action, set_user_permission
+
+
+@pytest.mark.parametrize('user_permission, user_action, expected_result',
+                         [(UserPermission.READ_ONLY, UserAction.ACKNOWLEDGE, False),
+                          (UserPermission.READ_ONLY, UserAction.ENABLE, False),
+                          (UserPermission.READ_ONLY, UserAction.UPDATE_CONFIG, False),
+                          (UserPermission.OPERATOR, UserAction.ACKNOWLEDGE, True),
+                          (UserPermission.OPERATOR, UserAction.ENABLE, False),
+                          (UserPermission.OPERATOR, UserAction.UPDATE_CONFIG, False),
+                          (UserPermission.ADMIN, UserAction.ACKNOWLEDGE, True),
+                          (UserPermission.ADMIN, UserAction.ENABLE, True),
+                          (UserPermission.ADMIN, UserAction.UPDATE_CONFIG, True)])
+def test_can_take_action(user_permission, user_action, expected_result):
+    """ A simple test for ensuring that all pairs of user action/user permission are handled properly"""
+    set_user_permission(user_permission)
+    action_allowed = can_take_action(user_action)
+    assert action_allowed == expected_result

--- a/slam_launcher/main.py
+++ b/slam_launcher/main.py
@@ -19,7 +19,7 @@ def main():
 
     logging.basicConfig(level=app_args.log.upper())
 
-    permissions.user_permission = permissions.UserPermission(app_args.user_permissions)
+    permissions.set_user_permission(permissions.UserPermission(app_args.user_permissions))
 
     topics = app_args.topics.split(',')
     kafka_boostrap_servers = app_args.bootstrap_servers.split(',')

--- a/slam_launcher/main.py
+++ b/slam_launcher/main.py
@@ -12,7 +12,7 @@ def main():
     parser.add_argument('--bootstrap-servers',
                         default='localhost:9092',
                         help='Comma separated list of urls for one or more kafka boostrap servers')
-    parser.add_argument('--user-permissions', default='read-only', help='One of read-only, operator, admin')
+    parser.add_argument('--user-permissions', default='admin', help='One of read-only, operator, admin')
     parser.add_argument('--log', default='warning', help='Logging level. debug, info, warning, error, critical')
 
     app_args = parser.parse_args()

--- a/slam_launcher/main.py
+++ b/slam_launcher/main.py
@@ -3,7 +3,7 @@ import logging
 import sys
 
 from qtpy.QtWidgets import QApplication
-from slam import AlarmHandlerMainWindow
+from slam import AlarmHandlerMainWindow, permissions
 
 
 def main():
@@ -12,11 +12,14 @@ def main():
     parser.add_argument('--bootstrap-servers',
                         default='localhost:9092',
                         help='Comma separated list of urls for one or more kafka boostrap servers')
+    parser.add_argument('--user-permissions', default='read-only', help='One of read-only, operator, admin')
     parser.add_argument('--log', default='warning', help='Logging level. debug, info, warning, error, critical')
 
     app_args = parser.parse_args()
 
     logging.basicConfig(level=app_args.log.upper())
+
+    permissions.user_permission = permissions.UserPermission(app_args.user_permissions)
 
     topics = app_args.topics.split(',')
     kafka_boostrap_servers = app_args.bootstrap_servers.split(',')


### PR DESCRIPTION
Adds read-only, operator, and admin permissions to the application which determine what actions a user is allowed to take. Very simple implementation at this time as individual user accounts aren't supported for this, it is just set at startup. Mostly just to defend against accidental changes.