### PR TITLE
FIX: Remove non-existent alarm paths from table when an action is taken

### DIFF
--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -190,7 +190,7 @@ class AlarmHandlerMainWindow(QMainWindow):
         key = message.key
         values = message.value
         if key.startswith('config'):  # [7:] because config:
-            logger.debug(f'Processing CONFIG message with key: {message.key} and values: {message.value}')
+            print(f'Processing CONFIG message with key: {message.key} and values: {message.value}')
             alarm_config_name = key.split('/')[1]
             if values is not None:
                 # Start from 7: to read past the 'config:' part of the key
@@ -207,9 +207,13 @@ class AlarmHandlerMainWindow(QMainWindow):
             pv = message.key.split('/')[-1]
             alarm_config_name = key.split('/')[1]
             self.last_received_update_time[alarm_config_name] = datetime.now()
-            logger.debug(f'Processing STATE message with key: {message.key} and values: {message.value}')
-            if values is None or len(values) <= 2:
-                return  # This is either a misconfigured message, or the heartbeat message which doesn't get recorded
+            print(f'Processing STATE message with key: {message.key} and values: {message.value}')
+            if values is None:
+                self.active_alarm_tables[alarm_config_name].alarmModel.remove_row(message.key[6:].split('/')[-1])
+                self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(message.key[6:].split('/')[-1])
+                return
+            if len(values) <= 2:
+                return  # This is the heartbeat message which doesn't get recorded
             time = ''
             if 'time' in values:
                 time = datetime.fromtimestamp(values['time']['seconds'])

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -190,7 +190,7 @@ class AlarmHandlerMainWindow(QMainWindow):
         key = message.key
         values = message.value
         if key.startswith('config'):  # [7:] because config:
-            print(f'Processing CONFIG message with key: {message.key} and values: {message.value}')
+            logger.debug(f'Processing CONFIG message with key: {message.key} and values: {message.value}')
             alarm_config_name = key.split('/')[1]
             if values is not None:
                 # Start from 7: to read past the 'config:' part of the key
@@ -207,7 +207,7 @@ class AlarmHandlerMainWindow(QMainWindow):
             pv = message.key.split('/')[-1]
             alarm_config_name = key.split('/')[1]
             self.last_received_update_time[alarm_config_name] = datetime.now()
-            print(f'Processing STATE message with key: {message.key} and values: {message.value}')
+            logger.debug(f'Processing STATE message with key: {message.key} and values: {message.value}')
             if values is None:
                 self.active_alarm_tables[alarm_config_name].alarmModel.remove_row(message.key[6:].split('/')[-1])
                 self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(message.key[6:].split('/')[-1])

--- a/slam/tests/test_alarm_table_view.py
+++ b/slam/tests/test_alarm_table_view.py
@@ -58,7 +58,7 @@ def test_send_acknowledgement(qtbot, monkeypatch, active_alarm_table_view, mock_
     monkeypatch.setattr(model_index, 'row', lambda: 0)
 
     # Send the acknowledgement, and verify the message we are sending to kafka looks the way we want it to
-    active_alarm_table_view.send_acknowledgement()
+    active_alarm_table_view.send_acknowledge_action(True)
     # Setting the correct topic, path, and acknowledgement command is all we need to acknowledge an alarm
     assert mock_kafka_producer.topic == 'TEST_TOPICCommand'
     assert mock_kafka_producer.key == 'command:/path/to/TEST:PV'
@@ -81,7 +81,7 @@ def test_send_unacknowledgement(qtbot, monkeypatch, acknowledged_alarm_table_vie
     monkeypatch.setattr(model_index, 'row', lambda: 0)
 
     # Send the unacknowledgement, and verify the message we are sending to kafka looks the way we want it to
-    acknowledged_alarm_table_view.send_unacknowledgement()
+    acknowledged_alarm_table_view.send_acknowledge_action(False)
     # Setting the correct topic, path, and acknoledgement command is all we need to acknowledge an alarm
     assert mock_kafka_producer.topic == 'TEST_TOPICCommand'
     assert mock_kafka_producer.key == 'command:/path/to/TEST:PV'


### PR DESCRIPTION
When a new alarm configuration is created that removes some alarms which are currently in an alarm state, they stick around in the state topic in kafka. This will send a delete message to kafka to ensure they are cleaned up.