### PR TITLE
Rearrange column order

### DIFF
--- a/slam/alarm_table_model.py
+++ b/slam/alarm_table_model.py
@@ -21,8 +21,8 @@ class AlarmItemsTableModel(QAbstractTableModel):
     def __init__(self, parent: Optional[QObject] = None):
         super(QAbstractTableModel, self).__init__(parent=parent)
         self.alarm_items = OrderedDict()  # Key (str) to data
-        self.column_names = ('PV', 'Latched Severity', 'Latched Status', 'Description', 'Time', 'Alarm Value',
-                             'Current Severity', 'Current Status')
+        self.column_names = ('PV', 'Latched Severity', 'Current Severity', 'Description', 'Time', 'Value',
+                             'Latched Status', 'Current Status')
         self.column_to_attr = {0: 'name', 1: 'alarm_severity', 2: 'alarm_status', 3: 'description', 4: 'alarm_time',
                                5: 'alarm_value', 6: 'pv_severity', 7: 'pv_status'}
 

--- a/slam/alarm_table_model.py
+++ b/slam/alarm_table_model.py
@@ -23,8 +23,8 @@ class AlarmItemsTableModel(QAbstractTableModel):
         self.alarm_items = OrderedDict()  # Key (str) to data
         self.column_names = ('PV', 'Latched Severity', 'Current Severity', 'Description', 'Time', 'Value',
                              'Latched Status', 'Current Status')
-        self.column_to_attr = {0: 'name', 1: 'alarm_severity', 2: 'alarm_status', 3: 'description', 4: 'alarm_time',
-                               5: 'alarm_value', 6: 'pv_severity', 7: 'pv_status'}
+        self.column_to_attr = {0: 'name', 1: 'alarm_severity', 2: 'pv_severity', 3: 'description', 4: 'alarm_time',
+                               5: 'alarm_value', 6: 'alarm_status', 7: 'pv_status'}
 
     def rowCount(self, parent) -> int:
         """ Return the row count of the table """
@@ -69,7 +69,7 @@ class AlarmItemsTableModel(QAbstractTableModel):
             return alarm_item.description
         elif column_name == 'Time':
             return str(alarm_item.alarm_time)
-        elif column_name == 'Alarm Value':
+        elif column_name == 'Value':
             return alarm_item.alarm_value
         elif column_name == 'Current Severity':
             return alarm_item.pv_severity.value

--- a/slam/tests/test_alarm_table_model.py
+++ b/slam/tests/test_alarm_table_model.py
@@ -34,7 +34,7 @@ def test_get_data(alarm_table):
     assert alarm_table.getData('Latched Severity', alarm_item) == 'MAJOR'
     assert alarm_table.getData('Latched Status', alarm_item) == 'enabled'
     assert alarm_table.getData('Time', alarm_item) == '2022-01-02 00:10:00'
-    assert alarm_table.getData('Alarm Value', alarm_item) == 'FAULT'
+    assert alarm_table.getData('Value', alarm_item) == 'FAULT'
     assert alarm_table.getData('Current Severity', alarm_item) == 'MINOR'
     assert alarm_table.getData('Current Status', alarm_item) == 'enabled'
 
@@ -79,11 +79,11 @@ def test_remove_row(alarm_table):
 
 @pytest.mark.parametrize('column, expected_order', [(0, ('PV:MAJOR', 'PV:MINOR', 'PV:UNDEFINED')),
                                                     (1, ('PV:MINOR', 'PV:MAJOR', 'PV:UNDEFINED')),
-                                                    (2, ('PV:MAJOR', 'PV:MINOR', 'PV:UNDEFINED')),
+                                                    (2, ('PV:MINOR', 'PV:MAJOR', 'PV:UNDEFINED')),
                                                     (3, ('PV:MAJOR', 'PV:MINOR', 'PV:UNDEFINED')),
                                                     (4, ('PV:UNDEFINED', 'PV:MINOR', 'PV:MAJOR')),
                                                     (5, ('PV:MINOR', 'PV:MAJOR', 'PV:UNDEFINED')),
-                                                    (6, ('PV:MINOR', 'PV:MAJOR', 'PV:UNDEFINED')),
+                                                    (6, ('PV:MAJOR', 'PV:MINOR', 'PV:UNDEFINED')),
                                                     (7, ('PV:MAJOR', 'PV:MINOR', 'PV:UNDEFINED'))])
 def test_sort(alarm_table, column, expected_order):
     """ Test that the order of alarm items in the table is correct when sorting on every column """


### PR DESCRIPTION
change default column order to be PV, Latched Severity, Current Severity, Description, Time, Value, Latched Status, Current Status

![new_col_ordering](https://github.com/slaclab/slac-alarm-manager/assets/137955700/20d60ff1-27e9-405e-99ef-e1c9646075ee)
