### PR TITLE
Add 'All' topic option

### DIFF
--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -68,6 +68,7 @@ class AlarmTableViewWidget(QWidget):
         self.tree_model = tree_model  # We still need the tree hierarchy when dealing with acks at non leaf nodes
         self.kafka_producer = kafka_producer
         self.topic = topic
+        self.topics = [topic]
         self.table_type = table_type
         self.plot_slot = plot_slot
         self.plot_signal.connect(self.plot_slot)

--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -68,7 +68,6 @@ class AlarmTableViewWidget(QWidget):
         self.tree_model = tree_model  # We still need the tree hierarchy when dealing with acks at non leaf nodes
         self.kafka_producer = kafka_producer
         self.topic = topic
-        self.topics = [topic]
         self.table_type = table_type
         self.plot_slot = plot_slot
         self.plot_signal.connect(self.plot_slot)

--- a/slam/alarm_tree_model.py
+++ b/slam/alarm_tree_model.py
@@ -23,6 +23,7 @@ class AlarmItemsTreeModel(QAbstractItemModel):
         self.root_item = AlarmItem("")
         self.nodes = []
         self.enable_all_topic = enable_all_topic
+        # when we have multiple topics to display, make each topic-tree's root a child of a dummy root
         if self.enable_all_topic:
             self.nodes.insert(0, self.root_item)
         self.added_paths = dict()  # Mapping from PV name to all associated paths in the tree (will be just 1 for most)

--- a/slam/alarm_tree_model.py
+++ b/slam/alarm_tree_model.py
@@ -24,7 +24,7 @@ class AlarmItemsTreeModel(QAbstractItemModel):
         self.nodes = []
         self.enable_all_topic = enable_all_topic
         if self.enable_all_topic:
-            self.nodes.insert(0, self.root_item) 
+            self.nodes.insert(0, self.root_item)
         self.added_paths = dict()  # Mapping from PV name to all associated paths in the tree (will be just 1 for most)
 
     def clear(self) -> None:
@@ -211,10 +211,9 @@ class AlarmItemsTreeModel(QAbstractItemModel):
             # if multiple topic root-nodes then make then child of an dummy overall root-node
             if parent_path == "":
                 logger.debug(f"Setting root of alarm tree to: {item_path}")
-                print(f"Setting root of alarm tree to: {item_path}")
                 if self.enable_all_topic:
                     alarm_item.assign_parent(self.root_item)
-                    self.nodes[0].append_child(alarm_item) # when 'All' topic enabled, nodes[0] is root of topic trees
+                    self.nodes[0].append_child(alarm_item)  # when 'All' topic enabled, nodes[0] is root of topic trees
                 else:
                     self.root_item = alarm_item
                 return
@@ -228,7 +227,6 @@ class AlarmItemsTreeModel(QAbstractItemModel):
             self.endInsertRows()
 
         else:  # Otherwise it is an update to an existing item
-
             for alarm_path in self.added_paths[item_name]:
                 item_index = self.getItemIndex(alarm_path)
                 self.nodes[item_index].description = values.get("description")

--- a/slam/alarm_tree_model.py
+++ b/slam/alarm_tree_model.py
@@ -208,7 +208,7 @@ class AlarmItemsTreeModel(QAbstractItemModel):
             parent_path = "/".join(path_as_list[0:-1])
 
             # If the node has no parent, it must be the root-node of a topic's tree,
-            # if multiple topic root-nodes then make then child of an dummy overall root-node
+            # if we have multiple topic root-nodes then make them children of a dummy root-node
             if parent_path == "":
                 logger.debug(f"Setting root of alarm tree to: {item_path}")
                 if self.enable_all_topic:

--- a/slam/alarm_tree_model.py
+++ b/slam/alarm_tree_model.py
@@ -18,11 +18,13 @@ class AlarmItemsTreeModel(QAbstractItemModel):
         The parent of this model.
     """
 
-    def __init__(self, parent: Optional[QObject] = None):
+    def __init__(self, enable_all_topic: bool = False, parent: Optional[QObject] = None):
         super().__init__(parent)
         self.root_item = AlarmItem("")
-        self.has_multiple_topics = False
         self.nodes = []
+        self.enable_all_topic = enable_all_topic
+        if self.enable_all_topic:
+            self.nodes.insert(0, self.root_item) 
         self.added_paths = dict()  # Mapping from PV name to all associated paths in the tree (will be just 1 for most)
 
     def clear(self) -> None:
@@ -209,15 +211,13 @@ class AlarmItemsTreeModel(QAbstractItemModel):
             # if multiple topic root-nodes then make then child of an dummy overall root-node
             if parent_path == "":
                 logger.debug(f"Setting root of alarm tree to: {item_path}")
-                if not self.has_multiple_topics:
-                    self.has_multiple_topics = True
-                    self.root_item = alarm_item
-                else:
-                    self.nodes.insert(0, self.root_item)
+                print(f"Setting root of alarm tree to: {item_path}")
+                if self.enable_all_topic:
                     alarm_item.assign_parent(self.root_item)
-                    self.nodes[0].append_child(alarm_item)
+                    self.nodes[0].append_child(alarm_item) # when 'All' topic enabled, nodes[0] is root of topic trees
+                else:
+                    self.root_item = alarm_item
                 return
-            
 
             parent_item_index = self.getItemIndex(parent_path)
             if parent_item_index == -1:

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -31,7 +31,7 @@ class AlarmTreeViewWidget(QWidget):
 
     plot_signal = Signal(str)
 
-    def __init__(self, kafka_producer: KafkaProducer, topic: str, plot_slot: Callable):
+    def __init__(self, kafka_producer: KafkaProducer, topic: str, plot_slot: Callable, enable_all_topic: bool = False,):
         super().__init__()
 
         self.kafka_producer = kafka_producer
@@ -42,7 +42,7 @@ class AlarmTreeViewWidget(QWidget):
 
         self.setFont(QFont("Arial", 12))
         self.layout = QVBoxLayout(self)
-        self.treeModel = AlarmItemsTreeModel()
+        self.treeModel = AlarmItemsTreeModel(enable_all_topic)
         self.tree_view = QTreeView(self)
         self.tree_view.setProperty("showDropIndicator", False)
         self.tree_view.setDragDropOverwriteMode(False)

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -36,7 +36,6 @@ class AlarmTreeViewWidget(QWidget):
 
         self.kafka_producer = kafka_producer
         self.topic = topic
-        self.topics = [topic]
         self.plot_slot = plot_slot
         self.plot_signal.connect(self.plot_slot)
         self.clipboard = QApplication.clipboard()
@@ -247,9 +246,11 @@ class AlarmTreeViewWidget(QWidget):
                     values_to_send = self.create_config_values_for_action(alarm, enabled, acknowledged)
                     if enabled is not None and enabled != alarm.is_enabled():
                         # Changes to enabled status go to the regular topic
+
+                        # empty topic string means this is the 'All' topic tree-vew and doesn't have a valid kafka topic,
+                        # so grab the destination topic from the alarm's path.
                         if self.topic == "":
-                            for currTopic in self.topics:
-                                self.kafka_producer.send(currTopic, key=f"config:{alarm_path}", value=values_to_send)
+                            self.kafka_producer.send(alarm_path.split('/')[1], key=f"config:{alarm_path}", value=values_to_send)
                         else:
                             self.kafka_producer.send(self.topic, key=f"config:{alarm_path}", value=values_to_send)
                     if acknowledged is not None and acknowledged != alarm.is_acknowledged():

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -31,7 +31,13 @@ class AlarmTreeViewWidget(QWidget):
 
     plot_signal = Signal(str)
 
-    def __init__(self, kafka_producer: KafkaProducer, topic: str, plot_slot: Callable, enable_all_topic: bool = False,):
+    def __init__(
+        self,
+        kafka_producer: KafkaProducer,
+        topic: str,
+        plot_slot: Callable,
+        enable_all_topic: bool = False,
+    ):
         super().__init__()
 
         self.kafka_producer = kafka_producer
@@ -247,10 +253,12 @@ class AlarmTreeViewWidget(QWidget):
                     if enabled is not None and enabled != alarm.is_enabled():
                         # Changes to enabled status go to the regular topic
 
-                        # empty topic string means this is the 'All' topic tree-vew and doesn't have a valid kafka topic,
+                        # empty topic string means this is 'All' topic tree-vew and doesn't have a valid kafka topic,
                         # so grab the destination topic from the alarm's path.
                         if self.topic == "":
-                            self.kafka_producer.send(alarm_path.split('/')[1], key=f"config:{alarm_path}", value=values_to_send)
+                            self.kafka_producer.send(
+                                alarm_path.split("/")[1], key=f"config:{alarm_path}", value=values_to_send
+                            )
                         else:
                             self.kafka_producer.send(self.topic, key=f"config:{alarm_path}", value=values_to_send)
                     if acknowledged is not None and acknowledged != alarm.is_acknowledged():

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -253,16 +253,19 @@ class AlarmTreeViewWidget(QWidget):
                     if enabled is not None and enabled != alarm.is_enabled():
                         # Changes to enabled status go to the regular topic
 
-                        # empty topic string means this is 'All' topic tree-vew and doesn't have a valid kafka topic,
+                        # "" topic string means this is 'All' topic tree-vew and doesn't its own valid kafka topic,
                         # so grab the destination topic from the alarm's path.
-                        if self.topic == "":
-                            self.kafka_producer.send(
-                                alarm_path.split("/")[1], key=f"config:{alarm_path}", value=values_to_send
-                            )
-                        else:
-                            self.kafka_producer.send(self.topic, key=f"config:{alarm_path}", value=values_to_send)
+                        curr_topic = self.topic
+                        if curr_topic == "":
+                            curr_topic = alarm_path.split("/")[1]
+                        print("Updating for topic: ", self.topic)
+                        self.kafka_producer.send(curr_topic, key=f"config:{alarm_path}", value=values_to_send)
                     if acknowledged is not None and acknowledged != alarm.is_acknowledged():
-                        # Changes to acknowledgement status go to the command topic
+                        # Changes to acknowledgement status go to the command topic.
+                        # Similar to the enabled-status above, grab the destination topic from the alarm's path.
+                        curr_topic = self.topic
+                        if curr_topic == "":
+                            curr_topic = alarm_path.split("/")[1]
                         self.kafka_producer.send(
-                            self.topic + "Command", key=f"command:{alarm_path}", value=values_to_send
+                            curr_topic + "Command", key=f"command:{alarm_path}", value=values_to_send
                         )

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -247,7 +247,6 @@ class AlarmTreeViewWidget(QWidget):
                     values_to_send = self.create_config_values_for_action(alarm, enabled, acknowledged)
                     if enabled is not None and enabled != alarm.is_enabled():
                         # Changes to enabled status go to the regular topic
-                        print ("Sending to kafka: ", self.topic, f"config:{alarm_path}", values_to_send)
                         if self.topic == "":
                             for currTopic in self.topics:
                                 self.kafka_producer.send(currTopic, key=f"config:{alarm_path}", value=values_to_send)

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -258,7 +258,6 @@ class AlarmTreeViewWidget(QWidget):
                         curr_topic = self.topic
                         if curr_topic == "":
                             curr_topic = alarm_path.split("/")[1]
-                        print("Updating for topic: ", self.topic)
                         self.kafka_producer.send(curr_topic, key=f"config:{alarm_path}", value=values_to_send)
                     if acknowledged is not None and acknowledged != alarm.is_acknowledged():
                         # Changes to acknowledgement status go to the command topic.

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -36,6 +36,7 @@ class AlarmTreeViewWidget(QWidget):
 
         self.kafka_producer = kafka_producer
         self.topic = topic
+        self.topics = [topic]
         self.plot_slot = plot_slot
         self.plot_signal.connect(self.plot_slot)
         self.clipboard = QApplication.clipboard()
@@ -246,7 +247,12 @@ class AlarmTreeViewWidget(QWidget):
                     values_to_send = self.create_config_values_for_action(alarm, enabled, acknowledged)
                     if enabled is not None and enabled != alarm.is_enabled():
                         # Changes to enabled status go to the regular topic
-                        self.kafka_producer.send(self.topic, key=f"config:{alarm_path}", value=values_to_send)
+                        print ("Sending to kafka: ", self.topic, f"config:{alarm_path}", values_to_send)
+                        if self.topic == "":
+                            for currTopic in self.topics:
+                                self.kafka_producer.send(currTopic, key=f"config:{alarm_path}", value=values_to_send)
+                        else:
+                            self.kafka_producer.send(self.topic, key=f"config:{alarm_path}", value=values_to_send)
                     if acknowledged is not None and acknowledged != alarm.is_acknowledged():
                         # Changes to acknowledgement status go to the command topic
                         self.kafka_producer.send(

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -69,7 +69,7 @@ class AlarmHandlerMainWindow(QMainWindow):
 
         self.alarm_trees = dict()
         if self.enable_all_topic:
-            self.all_alarms_tree = AlarmTreeViewWidget(self.kafka_producer, "", self.plot_pv)
+            self.all_alarms_tree = AlarmTreeViewWidget(self.kafka_producer, "", self.plot_pv, True)
             self.alarm_trees['All'] = self.all_alarms_tree
 
         self.active_alarm_tables = dict()
@@ -93,7 +93,7 @@ class AlarmHandlerMainWindow(QMainWindow):
         for topic in topics:
             self.last_received_update_time[topic] = datetime.now()
             self.alarm_select_combo_box.addItem(topic)
-            self.alarm_trees[topic] = AlarmTreeViewWidget(self.kafka_producer, topic, self.plot_pv)
+            self.alarm_trees[topic] = AlarmTreeViewWidget(self.kafka_producer, topic, self.plot_pv, False)
             self.active_alarm_tables[topic] = AlarmTableViewWidget(
                 self.alarm_trees[topic].treeModel, self.kafka_producer, topic, AlarmTableType.ACTIVE, self.plot_pv
             )
@@ -282,6 +282,7 @@ class AlarmHandlerMainWindow(QMainWindow):
             if values is not None:
                 # Start from 7: to read past the 'config:' part of the key
                 self.alarm_trees[alarm_config_name].treeModel.update_model(message.key[7:], values)
+                # the 'All' tree gets updated by all topics
                 if self.enable_all_topic:
                     self.alarm_trees['All'].treeModel.update_model(message.key[7:], values)
                 if "description" in values:

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -12,7 +12,6 @@ from .alarm_table_view import AlarmTableType, AlarmTableViewWidget
 from .alarm_tree_view import AlarmTreeViewWidget
 from .archive_search import ArchiveSearchWidget
 from .kafka_reader import KafkaReader
-from .alarm_item import AlarmItem
 
 logger = logging.getLogger(__name__)
 
@@ -65,14 +64,12 @@ class AlarmHandlerMainWindow(QMainWindow):
         # A combo box for choosing which alarm tree/table to display
         self.alarm_select_combo_box = QComboBox(self)
         self.alarm_select_combo_box.setFixedSize(120, 30)
-
         self.alarm_select_combo_box.currentTextChanged.connect(self.change_display)
         self.current_alarm_config = topics[0]
 
         self.alarm_trees = dict()
         if self.enable_all_topic:
             self.all_alarms_tree = AlarmTreeViewWidget(self.kafka_producer, "", self.plot_pv)
-            self.all_alarms_tree.topics = topics
             self.alarm_trees['All'] = self.all_alarms_tree
 
         self.active_alarm_tables = dict()
@@ -81,7 +78,6 @@ class AlarmHandlerMainWindow(QMainWindow):
             self.all_active_alarms_table = AlarmTableViewWidget(
                 self.all_alarms_tree.treeModel, self.kafka_producer, "", AlarmTableType.ACTIVE, self.plot_pv
             )
-            self.all_active_alarms_table.topics = topics
             self.active_alarm_tables['All'] = self.all_active_alarms_table
         
         self.acknowledged_alarm_tables = dict()
@@ -89,7 +85,6 @@ class AlarmHandlerMainWindow(QMainWindow):
             self.all_acknowledged_alarms_table = AlarmTableViewWidget(
                 self.all_alarms_tree.treeModel, self.kafka_producer, "", AlarmTableType.ACKNOWLEDGED, self.plot_pv
             )
-            self.all_acknowledged_alarms_table.topics = topics
             self.acknowledged_alarm_tables['All'] = self.all_acknowledged_alarms_table
 
         self.last_received_update_time = {}  # Mapping from alarm config name to last kafka message received for it

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -41,7 +41,7 @@ class AlarmHandlerMainWindow(QMainWindow):
         )
         self.topics = topics
         self.descriptions = dict()  # Map from alarm path to description
-        self.enable_all_topic = True if len(topics) > 1 else False        
+        self.enable_all_topic = True if len(topics) > 1 else False
         self.all_alarms_tree = None
         self.all_active_alarms_table = None
         self.all_acknowledged_alarms_table = None
@@ -70,7 +70,7 @@ class AlarmHandlerMainWindow(QMainWindow):
         self.alarm_trees = dict()
         if self.enable_all_topic:
             self.all_alarms_tree = AlarmTreeViewWidget(self.kafka_producer, "", self.plot_pv, True)
-            self.alarm_trees['All'] = self.all_alarms_tree
+            self.alarm_trees["All"] = self.all_alarms_tree
 
         self.active_alarm_tables = dict()
 
@@ -78,14 +78,14 @@ class AlarmHandlerMainWindow(QMainWindow):
             self.all_active_alarms_table = AlarmTableViewWidget(
                 self.all_alarms_tree.treeModel, self.kafka_producer, "", AlarmTableType.ACTIVE, self.plot_pv
             )
-            self.active_alarm_tables['All'] = self.all_active_alarms_table
-        
+            self.active_alarm_tables["All"] = self.all_active_alarms_table
+
         self.acknowledged_alarm_tables = dict()
         if self.enable_all_topic:
             self.all_acknowledged_alarms_table = AlarmTableViewWidget(
                 self.all_alarms_tree.treeModel, self.kafka_producer, "", AlarmTableType.ACKNOWLEDGED, self.plot_pv
             )
-            self.acknowledged_alarm_tables['All'] = self.all_acknowledged_alarms_table
+            self.acknowledged_alarm_tables["All"] = self.all_acknowledged_alarms_table
 
         self.last_received_update_time = {}  # Mapping from alarm config name to last kafka message received for it
 
@@ -114,7 +114,7 @@ class AlarmHandlerMainWindow(QMainWindow):
                 .alarmView.horizontalHeader()
                 .resizeSection(logicalIndex, newSize)
             )
-        if self.enable_all_topic :
+        if self.enable_all_topic:
             self.alarm_select_combo_box.addItem("All")
 
         self.alarm_update_signal.connect(self.update_tree)
@@ -171,10 +171,10 @@ class AlarmHandlerMainWindow(QMainWindow):
             The name associated with the tree to update
         """
         self.alarm_trees[alarm_config_name].treeModel.update_item(*args)
-        
+
         # the 'All' table gets updated by all topics
         if self.enable_all_topic:
-            self.alarm_trees['All'].treeModel.update_item(*args)
+            self.alarm_trees["All"].treeModel.update_item(*args)
 
     def update_table(
         self,
@@ -197,8 +197,8 @@ class AlarmHandlerMainWindow(QMainWindow):
 
             # the 'All' table gets updated by all topics
             if self.enable_all_topic:
-                self.active_alarm_tables['All'].alarmModel.remove_row(name)
-                self.acknowledged_alarm_tables['All'].alarmModel.remove_row(name)
+                self.active_alarm_tables["All"].alarmModel.remove_row(name)
+                self.acknowledged_alarm_tables["All"].alarmModel.remove_row(name)
         elif severity in (
             AlarmSeverity.INVALID_ACK,
             AlarmSeverity.MAJOR_ACK,
@@ -211,8 +211,8 @@ class AlarmHandlerMainWindow(QMainWindow):
             )
 
             if self.enable_all_topic:
-                self.active_alarm_tables['All'].alarmModel.remove_row(name)
-                self.acknowledged_alarm_tables['All'].alarmModel.update_row(
+                self.active_alarm_tables["All"].alarmModel.remove_row(name)
+                self.acknowledged_alarm_tables["All"].alarmModel.update_row(
                     name, path, severity, status, time, value, pv_severity, pv_status, self.descriptions.get(path, "")
                 )
         elif severity == AlarmSeverity.OK:
@@ -220,8 +220,8 @@ class AlarmHandlerMainWindow(QMainWindow):
             self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(name)
 
             if self.enable_all_topic:
-                self.active_alarm_tables['All'].alarmModel.remove_row(name)
-                self.acknowledged_alarm_tables['All'].alarmModel.remove_row(name)
+                self.active_alarm_tables["All"].alarmModel.remove_row(name)
+                self.acknowledged_alarm_tables["All"].alarmModel.remove_row(name)
         else:
             if name in self.acknowledged_alarm_tables[alarm_config_name].alarmModel.alarm_items:
                 self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(name)
@@ -229,12 +229,11 @@ class AlarmHandlerMainWindow(QMainWindow):
                 name, path, severity, status, time, value, pv_severity, pv_status, self.descriptions.get(path, "")
             )
 
-            if self.enable_all_topic:                
-                self.acknowledged_alarm_tables['All'].alarmModel.remove_row(name)
-                self.active_alarm_tables['All'].alarmModel.update_row(
-                name, path, severity, status, time, value, pv_severity, pv_status, self.descriptions.get(path, "")
-                )            
-
+            if self.enable_all_topic:
+                self.acknowledged_alarm_tables["All"].alarmModel.remove_row(name)
+                self.active_alarm_tables["All"].alarmModel.update_row(
+                    name, path, severity, status, time, value, pv_severity, pv_status, self.descriptions.get(path, "")
+                )
 
     def change_display(self, alarm_config_name: str) -> None:
         """
@@ -248,18 +247,18 @@ class AlarmHandlerMainWindow(QMainWindow):
         alarm_tree_to_swap = None
         active_alarm_table_to_swap = None
         ack_alarm_table_to_swap = None
-        
+
         if alarm_config_name not in self.alarm_trees and alarm_config_name != "All":
             return
         elif alarm_config_name == "All":
             alarm_tree_to_swap = self.all_alarms_tree
             active_alarm_table_to_swap = self.all_active_alarms_table
             ack_alarm_table_to_swap = self.all_acknowledged_alarms_table
-        else: 
+        else:
             alarm_tree_to_swap = self.alarm_trees[alarm_config_name]
             active_alarm_table_to_swap = self.active_alarm_tables[alarm_config_name]
             ack_alarm_table_to_swap = self.acknowledged_alarm_tables[alarm_config_name]
-        
+
         self.horizontal_splitter.replaceWidget(0, alarm_tree_to_swap)
         self.vertical_splitter.replaceWidget(0, active_alarm_table_to_swap)
         self.vertical_splitter.replaceWidget(1, ack_alarm_table_to_swap)
@@ -284,7 +283,7 @@ class AlarmHandlerMainWindow(QMainWindow):
                 self.alarm_trees[alarm_config_name].treeModel.update_model(message.key[7:], values)
                 # the 'All' tree gets updated by all topics
                 if self.enable_all_topic:
-                    self.alarm_trees['All'].treeModel.update_model(message.key[7:], values)
+                    self.alarm_trees["All"].treeModel.update_model(message.key[7:], values)
                 if "description" in values:
                     self.descriptions[message.key[7:]] = values.get("description")
             else:  # A null message indicates this item should be removed from the tree
@@ -293,9 +292,9 @@ class AlarmHandlerMainWindow(QMainWindow):
                 self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(message.key[7:].split("/")[-1])
 
                 if self.enable_all_topic:
-                    self.alarm_trees['All'].treeModel.remove_item(message.key[7:])
-                    self.active_alarm_tables['All'].alarmModel.remove_row(message.key[7:].split("/")[-1])
-                    self.acknowledged_alarm_tables['All'].alarmModel.remove_row(message.key[7:].split("/")[-1])
+                    self.alarm_trees["All"].treeModel.remove_item(message.key[7:])
+                    self.active_alarm_tables["All"].alarmModel.remove_row(message.key[7:].split("/")[-1])
+                    self.acknowledged_alarm_tables["All"].alarmModel.remove_row(message.key[7:].split("/")[-1])
         elif key.startswith("command"):
             pass  # Nothing for us to do
         elif key.startswith("state"):
@@ -303,15 +302,15 @@ class AlarmHandlerMainWindow(QMainWindow):
             alarm_config_name = key.split("/")[1]
             self.last_received_update_time[alarm_config_name] = datetime.now()
             if self.enable_all_topic:
-                self.last_received_update_time['All'] = datetime.now()
+                self.last_received_update_time["All"] = datetime.now()
             logger.debug(f"Processing STATE message with key: {message.key} and values: {message.value}")
             if values is None:
                 self.active_alarm_tables[alarm_config_name].alarmModel.remove_row(message.key[6:].split("/")[-1])
                 self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(message.key[6:].split("/")[-1])
 
                 if self.enable_all_topic:
-                    self.active_alarm_tables['All'].alarmModel.remove_row(message.key[6:].split("/")[-1])
-                    self.acknowledged_alarm_tables['All'].alarmModel.remove_row(message.key[6:].split("/")[-1])
+                    self.active_alarm_tables["All"].alarmModel.remove_row(message.key[6:].split("/")[-1])
+                    self.acknowledged_alarm_tables["All"].alarmModel.remove_row(message.key[6:].split("/")[-1])
                 return
             if len(values) <= 2:
                 return  # This is the heartbeat message which doesn't get recorded

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -60,6 +60,8 @@ class AlarmHandlerMainWindow(QMainWindow):
         # A combo box for choosing which alarm tree/table to display
         self.alarm_select_combo_box = QComboBox(self)
         self.alarm_select_combo_box.setFixedSize(120, 30)
+        if len(topics) > 1:
+            self.alarm_select_combo_box.addItem("All")
         self.alarm_select_combo_box.currentTextChanged.connect(self.change_display)
         self.current_alarm_config = topics[0]
 

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -141,7 +141,7 @@ class AlarmHandlerMainWindow(QMainWindow):
         # The active and acknowledged alarm tables will appear in their own right-hand vertical split
         self.vertical_splitter = QSplitter(self)
         self.vertical_splitter.setOrientation(Qt.Orientation.Vertical)
-        self.vertical_splitter.addWidget(self.active_alarm_tables[topics[1]])
+        self.vertical_splitter.addWidget(self.active_alarm_tables[topics[0]])
         self.vertical_splitter.addWidget(self.acknowledged_alarm_tables[topics[0]])
         self.horizontal_splitter.addWidget(self.alarm_trees[topics[0]])
         self.horizontal_splitter.addWidget(self.vertical_splitter)
@@ -185,16 +185,6 @@ class AlarmHandlerMainWindow(QMainWindow):
         """
         A slot for updating an alarm table
         """
-        '''
-        print ("Alarm config name: ", alarm_config_name)
-        if alarm_config_name == "LCLS":
-            self.active_alarm_tables[alarm_config_name].alarmModel.append(AlarmItem("NOLAN"))
-            self.active_alarm_tables['LCLS'].alarmModel.append(self.active_alarm_tables['CRYO'].alarmModel.alarm_items.items()[1])
-            #print (self.active_alarm_tables['CRYO'].alarmModel.alarm_items.items())
-            #for _, currAlarmItem in self.active_alarm_tables['CRYO'].alarmModel.alarm_items.items():
-                #print ("Appending curr alarm item: ", currAlarmItem)
-                #self.active_alarm_tables['LCLS'].alarmModel.append(currAlarmItem)
-        '''
         if status == "Disabled":
             self.active_alarm_tables[alarm_config_name].alarmModel.remove_row(name)
             self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(name)
@@ -277,10 +267,8 @@ class AlarmHandlerMainWindow(QMainWindow):
         if key.startswith("config"):  # [7:] because config:
             logger.debug(f"Processing CONFIG message with key: {message.key} and values: {message.value}")
             alarm_config_name = key.split("/")[1]
-            #print ("!! alarm config name: ", alarm_config_name)
             if values is not None:
                 # Start from 7: to read past the 'config:' part of the key
-                #print ("XX@#@: ", message.key[7:])
                 self.alarm_trees[alarm_config_name].treeModel.update_model(message.key[7:], values)
                 self.alarm_trees['All'].treeModel.update_model(message.key[7:], values)
                 if "description" in values:

--- a/slam/tests/test_main_window.py
+++ b/slam/tests/test_main_window.py
@@ -121,7 +121,7 @@ def test_all_topic(qtbot, main_window, tree_model, mock_kafka_producer):
     # Test that topic-selection combo box has option for 'All'
     comboBox = all_topic_main_window.alarm_select_combo_box
     comboBoxOptions = [comboBox.itemText(i) for i in range(comboBox.count())]
-    assert 'All' in comboBoxOptions
+    assert "All" in comboBoxOptions
 
     # Send table updates to populate the topics with some alarms.
     # We expect the 'All' topic will get updated with these as well as the specified topic.
@@ -141,7 +141,7 @@ def test_all_topic(qtbot, main_window, tree_model, mock_kafka_producer):
     # Expect 'All' topic to have all alarms across the 2 topics: 3 active and 1 acknowledged
     assert len(all_topic_main_window.active_alarm_tables["TOPIC_1"].alarmModel.alarm_items) == 2
     assert len(all_topic_main_window.acknowledged_alarm_tables["TOPIC_1"].alarmModel.alarm_items) == 0
-    
+
     assert len(all_topic_main_window.active_alarm_tables["TOPIC_2"].alarmModel.alarm_items) == 1
     assert len(all_topic_main_window.acknowledged_alarm_tables["TOPIC_2"].alarmModel.alarm_items) == 1
 
@@ -154,7 +154,7 @@ def test_all_topic(qtbot, main_window, tree_model, mock_kafka_producer):
     )
     assert len(all_topic_main_window.active_alarm_tables["All"].alarmModel.alarm_items) == 2
     assert len(all_topic_main_window.acknowledged_alarm_tables["All"].alarmModel.alarm_items) == 2
-    
+
 
 def test_check_server_status(qtbot, main_window):
     """Verify that the disconnected alarm server banner shows and hides as expected"""

--- a/slam/tests/test_main_window.py
+++ b/slam/tests/test_main_window.py
@@ -112,6 +112,50 @@ def test_update_tables(qtbot, main_window, tree_model, mock_kafka_producer):
     assert len(main_window.acknowledged_alarm_tables["TEST"].alarmModel.alarm_items) == 0
 
 
+def test_all_topic(qtbot, main_window, tree_model, mock_kafka_producer):
+    """Test that the 'All' topic menu-option appears and tables contain all other topic's data"""
+
+    all_topic_main_window = AlarmHandlerMainWindow(["TOPIC_1", "TOPIC_2"], ["localhost:9092"])
+    qtbot.addWidget(all_topic_main_window)
+
+    # Test that topic-selection combo box has option for 'All'
+    comboBox = all_topic_main_window.alarm_select_combo_box
+    comboBoxOptions = [comboBox.itemText(i) for i in range(comboBox.count())]
+    assert 'All' in comboBoxOptions
+
+    # Send table updates to populate the topics with some alarms.
+    # We expect the 'All' topic will get updated with these as well as the specified topic.
+    all_topic_main_window.update_table(
+        "TOPIC_1", "ACTIVE:ALARM_1", "", AlarmSeverity.MAJOR, "Enabled", None, "", AlarmSeverity.MAJOR, ""
+    )
+    all_topic_main_window.update_table(
+        "TOPIC_1", "ACTIVE:ALARM_2", "", AlarmSeverity.MAJOR, "Enabled", None, "", AlarmSeverity.MAJOR, ""
+    )
+    all_topic_main_window.update_table(
+        "TOPIC_2", "ACTIVE:ALARM_3", "", AlarmSeverity.MAJOR, "Enabled", None, "", AlarmSeverity.MAJOR, ""
+    )
+    all_topic_main_window.update_table(
+        "TOPIC_2", "ACK:ALARM", "", AlarmSeverity.MAJOR_ACK, "Enabled", None, "", AlarmSeverity.MAJOR, ""
+    )
+
+    # Expect 'All' topic to have all alarms across the 2 topics: 3 active and 1 acknowledged
+    assert len(all_topic_main_window.active_alarm_tables["TOPIC_1"].alarmModel.alarm_items) == 2
+    assert len(all_topic_main_window.acknowledged_alarm_tables["TOPIC_1"].alarmModel.alarm_items) == 0
+    
+    assert len(all_topic_main_window.active_alarm_tables["TOPIC_2"].alarmModel.alarm_items) == 1
+    assert len(all_topic_main_window.acknowledged_alarm_tables["TOPIC_2"].alarmModel.alarm_items) == 1
+
+    assert len(all_topic_main_window.active_alarm_tables["All"].alarmModel.alarm_items) == 3
+    assert len(all_topic_main_window.acknowledged_alarm_tables["All"].alarmModel.alarm_items) == 1
+
+    # Now confirm that an updating alarm in 'TOPIC_2' also updates it in 'All'
+    all_topic_main_window.update_table(
+        "TOPIC_2", "ACTIVE:ALARM_3", "", AlarmSeverity.MAJOR_ACK, "Enabled", None, "", AlarmSeverity.MAJOR, ""
+    )
+    assert len(all_topic_main_window.active_alarm_tables["All"].alarmModel.alarm_items) == 2
+    assert len(all_topic_main_window.acknowledged_alarm_tables["All"].alarmModel.alarm_items) == 2
+    
+
 def test_check_server_status(qtbot, main_window):
     """Verify that the disconnected alarm server banner shows and hides as expected"""
     # When the application first starts up and has a fresh update, there should be no warning banner visible


### PR DESCRIPTION
When more than 1 topic specified, add option to topic drop-down for 'All' which displays all the alarms across all topics in one tree-view and set of tables.

to try feature:
on dev-rhel7 machine: 
-slam --topics LCLS,CRYO --bootstrap-servers 172.24.5.224:9094
-select 'All' from drop-down menu in top left of application window
-tree view and tables should display alarms from all specified topics, should be able to enable/disable/ack alarms as usual