### PR TITLE
Display thresholds

### DIFF
--- a/slam/alarm_item.py
+++ b/slam/alarm_item.py
@@ -162,15 +162,15 @@ class AlarmItem(QObject):
         """
         A convenience method for returning whether or not this item is undefiend or invalid.
         (Basically returns if the alarm-item is colored some shade of purple)
-        This function is useful to check before calling some PyEpics calls like "cainfo",
-        which takes long time to return when called on undefined/invalid alarms. 
+        This function is useful to check before using some PyEpics calls like "cainfo",
+        which takes long time to return when called on undefined/invalid alarms.
         """
         return self.alarm_severity in (
             AlarmSeverity.UNDEFINED,
             AlarmSeverity.UNDEFINED_ACK,
             AlarmSeverity.INVALID,
             AlarmSeverity.INVALID_ACK,
-        ) 
+        )
 
     def is_in_active_alarm_state(self) -> bool:
         """A convenience method for returning whether or not this item is actively in an alarm state"""
@@ -180,7 +180,6 @@ class AlarmItem(QObject):
             AlarmSeverity.INVALID,
             AlarmSeverity.UNDEFINED,
         )
-
 
     def display_color(self, severity) -> QBrush:
         """

--- a/slam/alarm_item.py
+++ b/slam/alarm_item.py
@@ -158,6 +158,20 @@ class AlarmItem(QObject):
             AlarmSeverity.UNDEFINED_ACK,
         )
 
+    def is_undefined_or_invalid(self) -> bool:
+        """
+        A convenience method for returning whether or not this item is undefiend or invalid.
+        (Basically returns if the alarm-item is colored some shade of purple)
+        This function is useful to check before calling some PyEpics calls like "cainfo",
+        which takes long time to return when called on undefined/invalid alarms. 
+        """
+        return self.alarm_severity in (
+            AlarmSeverity.UNDEFINED,
+            AlarmSeverity.UNDEFINED_ACK,
+            AlarmSeverity.INVALID,
+            AlarmSeverity.INVALID_ACK,
+        ) 
+
     def is_in_active_alarm_state(self) -> bool:
         """A convenience method for returning whether or not this item is actively in an alarm state"""
         return self.alarm_severity in (
@@ -166,6 +180,7 @@ class AlarmItem(QObject):
             AlarmSeverity.INVALID,
             AlarmSeverity.UNDEFINED,
         )
+
 
     def display_color(self, severity) -> QBrush:
         """

--- a/slam/alarm_item.py
+++ b/slam/alarm_item.py
@@ -130,6 +130,7 @@ class AlarmItem(QObject):
         self.annunciating = annunciating
         self.delay = delay
         self.alarm_filter = alarm_filter
+        self.pv_object = None
 
     def is_leaf(self) -> bool:
         """Return whether or not this alarm is associated with a leaf node in its configured hierarchy"""

--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -2,6 +2,7 @@ import enum
 import getpass
 import socket
 from functools import partial
+from epics import cainfo, PV
 from kafka.producer import KafkaProducer
 from qtpy.QtCore import QEvent, QModelIndex, QSortFilterProxyModel, Qt, Signal
 from qtpy.QtGui import QCursor
@@ -165,8 +166,30 @@ class AlarmTableViewWidget(QWidget):
         else:
             self.alarm_count_label.setText(f"Acknowledged Alarms: {len(self.alarmModel.alarm_items)}")
 
+    def getThresholdValues(self, alarm_item_path) -> List[str]:
+        
+        result = []
+        result.append(cainfo(alarm_item_path))
+ 
+        pv = PV(alarm_item_path)
+        print ("!!pv: ", pv)
+        '''
+        thresholds = ["LOW", "LOLO", "HIGH", "HIHI"]
+        for currThreshold in thresholds:
+            currPVName = alarm_item_path + "." + currThreshold
+            val = caget(currPVName)
+            result.append(val)
+        '''
+        return result
+
     def alarm_context_menu_event(self, ev: QEvent) -> None:
         """Display the right-click context menu for items in the active alarms table"""
+        indices = self.get_selected_indices()
+        if len(indices) > 0:
+            alarm_item = list(self.alarmModel.alarm_items.items())[indices[0].row()][1]
+        #print ("!!alarm_item path: ", alarm_item.name)
+        vals = self.getThresholdValues(alarm_item.name)
+        #print ("!!!vals: ", vals)
         self.alarm_context_menu.popup(QCursor.pos())
 
     def get_selected_indices(self) -> List[QModelIndex]:

--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -1,8 +1,8 @@
 import enum
 import getpass
 import socket
+import re
 from functools import partial
-from epics import cainfo, PV
 from kafka.producer import KafkaProducer
 from qtpy.QtCore import QEvent, QModelIndex, QSortFilterProxyModel, Qt, Signal
 from qtpy.QtGui import QCursor
@@ -20,11 +20,12 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from epics import cainfo
 from typing import Callable, List
 from .alarm_table_model import AlarmItemsTableModel
 from .alarm_tree_model import AlarmItemsTreeModel
 from .permissions import UserAction, can_take_action
-import re
+
 
 class AlarmTableType(str, enum.Enum):
     """
@@ -108,8 +109,7 @@ class AlarmTableViewWidget(QWidget):
         self.unacknowledge_action = QAction("Unacknowledge")
         self.copy_action = QAction("Copy PV To Clipboard")
         self.plot_action = QAction("Draw Plot")
-        self.display_threshholds_menu = QMenu("Display Alarm Thresholds")
-
+        self.display_thresholds_menu = QMenu("Display Alarm Thresholds")
         self.acknowledge_action.triggered.connect(partial(self.send_acknowledge_action, True))
         self.unacknowledge_action.triggered.connect(partial(self.send_acknowledge_action, False))
         self.plot_action.triggered.connect(self.plot_pv)
@@ -122,8 +122,8 @@ class AlarmTableViewWidget(QWidget):
 
         self.alarm_context_menu.addAction(self.copy_action)
         self.alarm_context_menu.addAction(self.plot_action)
-        self.alarm_context_menu.addMenu(self.display_threshholds_menu)
-        self.display_threshholds_menu.aboutToShow.connect(self.handleThresholdDisplay)
+        self.alarm_context_menu.addMenu(self.display_thresholds_menu)
+        self.display_thresholds_menu.aboutToShow.connect(self.handleThresholdDisplay)
 
         self.alarmView.contextMenuEvent = self.alarm_context_menu_event
 
@@ -148,30 +148,29 @@ class AlarmTableViewWidget(QWidget):
         self.layout.addWidget(self.alarmView)
 
         self.alarmModel.layoutChanged.connect(self.update_counter_label)
-        self.display_threshholds_menu.aboutToShow.connect(self.handleThresholdDisplay)
 
     def handleThresholdDisplay(self):
         indices = self.get_selected_indices()
-        index = indices[0]
-        alarm_item = None 
+        indices[0]
+        alarm_item = None
         if len(indices) > 0:
             alarm_item = list(self.alarmModel.alarm_items.items())[indices[0].row()][1]
 
         info = None
         hihi = high = low = lolo = "None"
 
-        # Avoid calling "cainfo" on undefined alarm since causes the call to stall for a bit.
+        # Avoid calling 'cainfo' on undefined alarm since causes the call to stall for a bit.
         # Also we don't want thresholds from an undefined alarm anyway.
         if alarm_item.is_undefined_or_invalid():
-            self.display_threshholds_menu.clear()
+            self.display_thresholds_menu.clear()
             return
 
-        info = cainfo(alarm_item.name, False) # False arg is so call returns string
-        print (info)
+        info = cainfo(alarm_item.name, False)  # False arg is so call returns string
+        print(info)
 
-        if info != None:
+        if info is not None:
             """
-            "cainfo" just returns string, so need regex to extract values,
+            'cainfo' just returns a string, so need regex to extract values,
             the following is example of values in the string:
 
              upper_alarm_limit   = 130.0
@@ -180,15 +179,15 @@ class AlarmTableViewWidget(QWidget):
              lower_warning_limit = 90.0
 
             """
-            upper_alarm_limit_pattern = re.compile(r'upper_alarm_limit\s*=\s*([\d.]+)')
-            lower_alarm_limit_pattern = re.compile(r'lower_alarm_limit\s*=\s*([\d.]+)')
-            upper_warning_limit_pattern = re.compile(r'upper_warning_limit\s*=\s*([\d.]+)')
-            lower_warning_limit_pattern = re.compile(r'lower_warning_limit\s*=\s*([\d.]+)')
+            upper_alarm_limit_pattern = re.compile(r"upper_alarm_limit\s*=\s*([\d.]+)")
+            lower_alarm_limit_pattern = re.compile(r"lower_alarm_limit\s*=\s*([\d.]+)")
+            upper_warning_limit_pattern = re.compile(r"upper_warning_limit\s*=\s*([\d.]+)")
+            lower_warning_limit_pattern = re.compile(r"lower_warning_limit\s*=\s*([\d.]+)")
 
             hihi_search_result = upper_alarm_limit_pattern.search(info)
-            # threshold values are not always set 
+            # threshold values are not always set
             hihi = hihi_search_result.group(1) if hihi_search_result else "None"
-            
+
             high_search_result = lower_alarm_limit_pattern.search(info)
             high = high_search_result.group(1) if high_search_result else "None"
 
@@ -198,15 +197,14 @@ class AlarmTableViewWidget(QWidget):
             lolo_search_result = lower_warning_limit_pattern.search(info)
             lolo = lolo_search_result.group(1) if lolo_search_result else "None"
 
-
         self.hihi_action = QAction("HIHI: " + hihi)
         self.high_action = QAction("HIGH: " + high)
         self.low_action = QAction("LOW: " + low)
         self.lolo_action = QAction("LOLO: " + lolo)
-        self.display_threshholds_menu.addAction(self.hihi_action)
-        self.display_threshholds_menu.addAction(self.high_action)
-        self.display_threshholds_menu.addAction(self.low_action)
-        self.display_threshholds_menu.addAction(self.lolo_action)
+        self.display_thresholds_menu.addAction(self.hihi_action)
+        self.display_thresholds_menu.addAction(self.high_action)
+        self.display_thresholds_menu.addAction(self.low_action)
+        self.display_thresholds_menu.addAction(self.lolo_action)
 
     def filter_table(self) -> None:
         """Filter the table based on the text typed into the filter bar"""
@@ -233,9 +231,7 @@ class AlarmTableViewWidget(QWidget):
         """Display the right-click context menu for items in the active alarms table"""
         indices = self.get_selected_indices()
         if len(indices) > 0:
-            alarm_item = list(self.alarmModel.alarm_items.items())[indices[0].row()][1]
-        #print ("!!alarm_item path: ", alarm_item.name)
-        #print ("!!!vals: ", vals)
+            list(self.alarmModel.alarm_items.items())[indices[0].row()][1]
         self.alarm_context_menu.popup(QCursor.pos())
 
     def get_selected_indices(self) -> List[QModelIndex]:

--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -150,14 +150,14 @@ class AlarmTableViewWidget(QWidget):
         self.alarmModel.layoutChanged.connect(self.update_counter_label)
 
     def handleThresholdDisplay(self):
-        # If multiple alarm-items selected, just display thresholds for 1st item.
-        # (or don't display anything if 1st item is undefined/invalid).
-        # This follows how the "Draw Plot" option handles multiple selected items.
         indices = self.get_selected_indices()
         alarm_item = None
         info = None
         hihi = high = low = lolo = "None"
 
+        # If multiple alarm-items selected, just display thresholds for 1st item.
+        # (or don't display anything if 1st item is undefined/invalid).
+        # This follows how the "Draw Plot" option handles multiple selected items.
         if len(indices) > 0:
             index = indices[0]
             alarm_item = list(self.alarmModel.alarm_items.items())[index.row()][1]

--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -182,7 +182,6 @@ class AlarmTableViewWidget(QWidget):
             alarm_item.pv_object.clear_auto_monitor()
 
         alarm_item_metadata = alarm_item.pv_object.get_ctrlvars()
-        print(alarm_item_metadata)
 
         # Getting data can fail for some PV's, good metadata will always have a key for all 4 limits (nan if not set),
         # in this case don't display any threshold sub-menus

--- a/slam/alarm_table_view.py
+++ b/slam/alarm_table_view.py
@@ -155,6 +155,9 @@ class AlarmTableViewWidget(QWidget):
         # This follows how the "Draw Plot" option handles multiple selected items.
         indices = self.get_selected_indices()
         alarm_item = None
+        info = None
+        hihi = high = low = lolo = "None"
+
         if len(indices) > 0:
             index = indices[0]
             alarm_item = list(self.alarmModel.alarm_items.items())[index.row()][1]
@@ -165,12 +168,10 @@ class AlarmTableViewWidget(QWidget):
         if not alarm_item.is_leaf():
             return
 
-        info = None
-        hihi = high = low = lolo = "None"
-
         # Avoid calling 'cainfo' on undefined alarm since causes the call to stall for a bit.
         # Also we don't want thresholds from an undefined alarm anyway.
         if alarm_item.is_undefined_or_invalid():
+            # Don't display any of the threshold-display actions if alarm-item undefined
             self.display_thresholds_menu.clear()
             return
 

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -1,5 +1,6 @@
 import getpass
 import socket
+import logging
 from functools import partial
 from kafka.producer import KafkaProducer
 from pydm.display import load_file
@@ -14,6 +15,7 @@ from .permissions import UserAction, can_take_action
 from math import isnan
 from epics import PV
 
+logger = logging.getLogger(__name__)
 
 class AlarmTreeViewWidget(QWidget):
     """
@@ -105,21 +107,22 @@ class AlarmTreeViewWidget(QWidget):
             # Don't display any of the threshold-display actions if alarm-item undefined
             self.display_thresholds_menu.clear()
             return
-
+        
+        # Make pv_object if first time item's threshold is requested
         if alarm_item.pv_object is None:
-            alarm_item.pv_object = PV(alarm_item.name)
             # Update the values only when user requests them in right-click menu
-            alarm_item.pv_object.clear_auto_monitor()
+            alarm_item.pv_object = PV(alarm_item.name, auto_monitor=False)
 
         alarm_item_metadata = alarm_item.pv_object.get_ctrlvars()
 
         # Getting data can fail for some PV's, good metadata will always have a key for all 4 limits (nan if not set),
         # in this case don't display any threshold sub-menus
-        if (
-            alarm_item_metadata is not None
-            and len(alarm_item_metadata) > 0
-            and "upper_alarm_limit" not in alarm_item_metadata
-        ):
+        if alarm_item_metadata is None:
+            logger.debug(f"Can't connect to PV: {alarm_item.name}")
+            self.display_thresholds_menu.clear()
+            return
+        elif len(alarm_item_metadata) > 0 and "upper_alarm_limit" not in alarm_item_metadata:
+            logger.debug(f"No threshold data for PV: {alarm_item.name}")
             self.display_thresholds_menu.clear()
             return
 

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -17,6 +17,7 @@ from epics import PV
 
 logger = logging.getLogger(__name__)
 
+
 class AlarmTreeViewWidget(QWidget):
     """
     The TreeViewWidget is a collection of everything needed to display and interact with the alarm tree.
@@ -107,7 +108,7 @@ class AlarmTreeViewWidget(QWidget):
             # Don't display any of the threshold-display actions if alarm-item undefined
             self.display_thresholds_menu.clear()
             return
-        
+
         # Make pv_object if first time item's threshold is requested
         if alarm_item.pv_object is None:
             # Update the values only when user requests them in right-click menu

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -92,6 +92,10 @@ class AlarmTreeViewWidget(QWidget):
         index = indices[0]
         alarm_item = self.treeModel.getItem(index)
 
+        # If not a leaf its an nvalid 'cainfo' call which could stall things for a while.
+        if not alarm_item.is_leaf():
+            return
+
         info = None
         hihi = high = low = lolo = "None"
 
@@ -131,6 +135,7 @@ class AlarmTreeViewWidget(QWidget):
             lolo_search_result = lower_warning_limit_pattern.search(info)
             lolo = lolo_search_result.group(1) if lolo_search_result else "None"
 
+        # we display threshold values as 4 items in a drop-down menu
         self.hihi_action = QAction("HIHI: " + hihi)
         self.high_action = QAction("HIGH: " + high)
         self.low_action = QAction("LOW: " + low)

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -91,17 +91,17 @@ class AlarmTreeViewWidget(QWidget):
         indices = self.tree_view.selectedIndexes()
         index = indices[0]
         alarm_item = self.treeModel.getItem(index)
+        info = None
+        hihi = high = low = lolo = "None"
 
         # If not a leaf its an nvalid 'cainfo' call which could stall things for a while.
         if not alarm_item.is_leaf():
             return
 
-        info = None
-        hihi = high = low = lolo = "None"
-
         # Avoid calling 'cainfo' on undefined alarm since causes the call to stall for a bit.
         # Also we don't want thresholds from an undefined alarm anyway.
         if alarm_item.is_undefined_or_invalid():
+            # Don't display any of the threshold-display actions if alarm-item undefined
             self.display_threshholds_menu.clear()
             return
 
@@ -148,9 +148,6 @@ class AlarmTreeViewWidget(QWidget):
     def tree_menu(self, pos: QPoint) -> None:
         """Creates and displays the context menu to be displayed upon right clicking on an alarm item"""
         indices = self.tree_view.selectedIndexes()
-        index = indices[0]
-        self.treeModel.getItem(index).name
-
         if len(indices) > 0:
             index = indices[0]
             alarm_item = self.treeModel.getItem(index)
@@ -172,7 +169,6 @@ class AlarmTreeViewWidget(QWidget):
                     self.context_menu.addAction(self.unacknowledge_action)
                 self.context_menu.addAction(self.copy_action)
                 self.context_menu.addAction(self.plot_action)
-
             else:  # Parent Node
                 leaf_nodes = self.treeModel.get_all_leaf_nodes(alarm_item)
                 add_acknowledge_action = False

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -113,6 +113,12 @@ class AlarmTreeViewWidget(QWidget):
             # Update the values only when user requests them in right-click menu
             alarm_item.pv_object = PV(alarm_item.name, auto_monitor=False)
 
+        # Do a get call we can quickly timeout, so if PV not-connected don't
+        # need to wait for slower get_ctrlvars() call.
+        # 0.1 is small arbitrary value, can be made larger if timing-out for
+        # actually connected PVs.
+        if alarm_item.pv_object.get(timeout=0.1) is None:
+            return
         alarm_item_metadata = alarm_item.pv_object.get_ctrlvars()
 
         # Getting data can fail for some PV's, good metadata will always have a key for all 4 limits (nan if not set),

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -1,5 +1,6 @@
 import getpass
 import socket
+import re
 from functools import partial
 from kafka.producer import KafkaProducer
 from pydm.display import load_file
@@ -11,9 +12,8 @@ from .alarm_configuration_widget import AlarmConfigurationWidget
 from .alarm_item import AlarmItem, AlarmSeverity
 from .alarm_tree_model import AlarmItemsTreeModel
 from .permissions import UserAction, can_take_action
-from epics import cainfo, PV, caget
-from typing import List
-import re
+from epics import cainfo
+
 
 class AlarmTreeViewWidget(QWidget):
     """
@@ -95,16 +95,16 @@ class AlarmTreeViewWidget(QWidget):
         info = None
         hihi = high = low = lolo = "None"
 
-        # Avoid calling "cainfo" on undefined alarm since causes the call to stall for a bit.
+        # Avoid calling 'cainfo' on undefined alarm since causes the call to stall for a bit.
         # Also we don't want thresholds from an undefined alarm anyway.
         if alarm_item.is_undefined_or_invalid():
             self.display_threshholds_menu.clear()
             return
 
-        info = cainfo(alarm_item.name, False) # False arg is so call returns string
-        if info != None:
+        info = cainfo(alarm_item.name, False)  # False arg is so call returns string
+        if info is not None:
             """
-            "cainfo" just returns string, so need regex to extract values,
+            'cainfo' just returns a string so need regex to extract values,
             the following is example of values in the string:
 
              upper_alarm_limit   = 130.0
@@ -113,15 +113,15 @@ class AlarmTreeViewWidget(QWidget):
              lower_warning_limit = 90.0
 
             """
-            upper_alarm_limit_pattern = re.compile(r'upper_alarm_limit\s*=\s*([\d.]+)')
-            lower_alarm_limit_pattern = re.compile(r'lower_alarm_limit\s*=\s*([\d.]+)')
-            upper_warning_limit_pattern = re.compile(r'upper_warning_limit\s*=\s*([\d.]+)')
-            lower_warning_limit_pattern = re.compile(r'lower_warning_limit\s*=\s*([\d.]+)')
+            upper_alarm_limit_pattern = re.compile(r"upper_alarm_limit\s*=\s*([\d.]+)")
+            lower_alarm_limit_pattern = re.compile(r"lower_alarm_limit\s*=\s*([\d.]+)")
+            upper_warning_limit_pattern = re.compile(r"upper_warning_limit\s*=\s*([\d.]+)")
+            lower_warning_limit_pattern = re.compile(r"lower_warning_limit\s*=\s*([\d.]+)")
 
             hihi_search_result = upper_alarm_limit_pattern.search(info)
-            # threshold values are not always set, just display "None" if so 
+            # threshold values are not always set, just display "None" if so
             hihi = hihi_search_result.group(1) if hihi_search_result else "None"
-            
+
             high_search_result = lower_alarm_limit_pattern.search(info)
             high = high_search_result.group(1) if high_search_result else "None"
 
@@ -131,7 +131,6 @@ class AlarmTreeViewWidget(QWidget):
             lolo_search_result = lower_warning_limit_pattern.search(info)
             lolo = lolo_search_result.group(1) if lolo_search_result else "None"
 
-
         self.hihi_action = QAction("HIHI: " + hihi)
         self.high_action = QAction("HIGH: " + high)
         self.low_action = QAction("LOW: " + low)
@@ -140,12 +139,12 @@ class AlarmTreeViewWidget(QWidget):
         self.display_threshholds_menu.addAction(self.high_action)
         self.display_threshholds_menu.addAction(self.low_action)
         self.display_threshholds_menu.addAction(self.lolo_action)
-    
+
     def tree_menu(self, pos: QPoint) -> None:
         """Creates and displays the context menu to be displayed upon right clicking on an alarm item"""
         indices = self.tree_view.selectedIndexes()
         index = indices[0]
-        name = self.treeModel.getItem(index).name
+        self.treeModel.getItem(index).name
 
         if len(indices) > 0:
             index = indices[0]

--- a/slam/alarm_tree_view.py
+++ b/slam/alarm_tree_view.py
@@ -125,11 +125,11 @@ class AlarmTreeViewWidget(QWidget):
         # Getting data can fail for some PV's, good metadata will always have a key for all 4 limits (nan if not set),
         # in this case don't display any threshold sub-menus
         if alarm_item_metadata is None:
-            logger.debug(f"Can't connect to PV: {alarm_item.name}")
+            logger.warn(f"Can't connect to PV: {alarm_item.name}")
             self.display_thresholds_menu.clear()
             return
         elif len(alarm_item_metadata) > 0 and "upper_alarm_limit" not in alarm_item_metadata:
-            logger.debug(f"No threshold data for PV: {alarm_item.name}")
+            logger.warn(f"No threshold data for PV: {alarm_item.name}")
             self.display_thresholds_menu.clear()
             return
 

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -209,6 +209,7 @@ class AlarmHandlerMainWindow(QMainWindow):
         """
         A slot for updating an alarm table
         """
+        #print ('!!! path: ', path, ",n ame: ", name)
         if status == "Disabled":
             self.active_alarm_tables[alarm_config_name].alarmModel.remove_row(name)
             self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(name)

--- a/slam/main_window.py
+++ b/slam/main_window.py
@@ -209,7 +209,6 @@ class AlarmHandlerMainWindow(QMainWindow):
         """
         A slot for updating an alarm table
         """
-        #print ('!!! path: ', path, ",n ame: ", name)
         if status == "Disabled":
             self.active_alarm_tables[alarm_config_name].alarmModel.remove_row(name)
             self.acknowledged_alarm_tables[alarm_config_name].alarmModel.remove_row(name)


### PR DESCRIPTION
*ignore typo in branch name (thresh**h**olds), not present in the code

to see in action:
-"slam --topics CRYO --bootstrap-servers 172.24.8.133:9094" on dev-rhl7
-in tree menu, Global->Distribution->WATR:BSYA: 100:COMP_AIR_P, right-click and "Display Thresholds", should see values for the 4 thresholds. 
-can right-click on other alarm-items in tree and should see "None" for most (no threshold set), or for undefined purple alarms you should see no sub-menus rendered under "Display Alarm Thresholds" menu.
-can try the same for table, but no alarms with thresholds currently active/ack'd