### PR TITLE
BUG: make alarm nodes be sorted alphabetically

### DIFF
--- a/slam/alarm_tree_model.py
+++ b/slam/alarm_tree_model.py
@@ -233,6 +233,8 @@ class AlarmItemsTreeModel(QAbstractItemModel):
                 parent_item_index = self.getItemIndex(parent_path)
             alarm_item.assign_parent(self.nodes[parent_item_index])
             self.nodes[parent_item_index].append_child(alarm_item)
+            # Sort nodes in alphabetical order
+            self.nodes[parent_item_index].child_items.sort(key=lambda x: x.name)
             self.endInsertRows()
 
         else:  # Otherwise it is an update to an existing item


### PR DESCRIPTION
Also fixes issue where disabled-nodes are placed
at bottom of list, now remains in sorted order.